### PR TITLE
feat(app-server): render live Spine agent trees in Codex App

### DIFF
--- a/codex-rs/app-server/BUILD.bazel
+++ b/codex-rs/app-server/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:defs.bzl", "codex_rust_crate")
 
 codex_rust_crate(
     name = "app-server",
+    compile_data = ["src/spine_ui/tree.html"],
     crate_name = "codex_app_server",
     extra_binaries = [
         "//codex-rs/bwrap:bwrap",

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -1153,6 +1153,24 @@ pub(crate) async fn apply_bespoke_event_handling(
             .await;
         }
         EventMsg::SpineTreeUpdate(spine_tree_event) => {
+            if crate::spine_ui::is_enabled() {
+                let live_spine_ui = {
+                    let mut state = thread_state.lock().await;
+                    state.record_spine_ui_snapshot(spine_tree_event.clone());
+                    state.live_spine_ui(&event_turn_id).cloned()
+                };
+                if let Some(notification) = live_spine_ui.as_ref().and_then(|spine_ui| {
+                    crate::spine_ui::snapshot_started_notification(
+                        &conversation_id.to_string(),
+                        &event_turn_id,
+                        spine_ui,
+                    )
+                }) {
+                    outgoing
+                        .send_server_notification(ServerNotification::ItemStarted(notification))
+                        .await;
+                }
+            }
             let notification = item_event_to_server_notification(
                 EventMsg::SpineTreeUpdate(spine_tree_event),
                 &conversation_id.to_string(),
@@ -1161,6 +1179,24 @@ pub(crate) async fn apply_bespoke_event_handling(
             outgoing.send_server_notification(notification).await;
         }
         EventMsg::SpineSpawnProgress(progress) => {
+            if crate::spine_ui::is_enabled() {
+                let live_spine_ui = {
+                    let mut state = thread_state.lock().await;
+                    state.record_spine_ui_spawn_progress(progress.clone());
+                    state.live_spine_ui(&event_turn_id).cloned()
+                };
+                if let Some(notification) = live_spine_ui.as_ref().and_then(|spine_ui| {
+                    crate::spine_ui::snapshot_started_notification(
+                        &conversation_id.to_string(),
+                        &event_turn_id,
+                        spine_ui,
+                    )
+                }) {
+                    outgoing
+                        .send_server_notification(ServerNotification::ItemStarted(notification))
+                        .await;
+                }
+            }
             let notification = item_event_to_server_notification(
                 EventMsg::SpineSpawnProgress(progress),
                 &conversation_id.to_string(),
@@ -1406,7 +1442,7 @@ async fn find_and_remove_turn_summary(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) -> TurnSummary {
     let mut state = thread_state.lock().await;
-    std::mem::take(&mut state.turn_summary)
+    state.take_turn_summary()
 }
 
 async fn handle_turn_complete(
@@ -1417,6 +1453,12 @@ async fn handle_turn_complete(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(conversation_id, thread_state).await;
+    thread_state
+        .lock()
+        .await
+        .set_spine_ui_terminal_connection_ids(&event_turn_id, outgoing.connection_ids());
+
+    emit_spine_ui_item_completed(conversation_id, &event_turn_id, &turn_summary, outgoing).await;
 
     let (status, error) = match turn_summary.last_error {
         Some(error) => (TurnStatus::Failed, Some(error)),
@@ -1446,6 +1488,12 @@ async fn handle_turn_interrupted(
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(conversation_id, thread_state).await;
+    thread_state
+        .lock()
+        .await
+        .set_spine_ui_terminal_connection_ids(&event_turn_id, outgoing.connection_ids());
+
+    emit_spine_ui_item_completed(conversation_id, &event_turn_id, &turn_summary, outgoing).await;
 
     emit_turn_completed_with_status(
         conversation_id,
@@ -1460,6 +1508,30 @@ async fn handle_turn_interrupted(
         outgoing,
     )
     .await;
+}
+
+async fn emit_spine_ui_item_completed(
+    conversation_id: ThreadId,
+    turn_id: &str,
+    turn_summary: &TurnSummary,
+    outgoing: &ThreadScopedOutgoingMessageSender,
+) {
+    if !crate::spine_ui::is_enabled() {
+        return;
+    }
+    let Some(spine_ui) = turn_summary.active_spine_ui(turn_id) else {
+        return;
+    };
+    let Some(notification) = crate::spine_ui::snapshot_completed_notification(
+        &conversation_id.to_string(),
+        turn_id,
+        spine_ui,
+    ) else {
+        return;
+    };
+    outgoing
+        .send_server_notification(ServerNotification::ItemCompleted(notification))
+        .await;
 }
 
 async fn handle_thread_rollback_failed(

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -111,6 +111,7 @@ mod request_processors;
 mod request_serialization;
 mod server_request_error;
 mod skills_watcher;
+mod spine_ui;
 mod thread_state;
 mod thread_status;
 mod transport;

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -372,6 +372,7 @@ impl MessageProcessor {
         let mcp_processor = McpRequestProcessor::new(
             auth_manager.clone(),
             Arc::clone(&thread_manager),
+            thread_state_manager.clone(),
             outgoing.clone(),
             config_manager.clone(),
         );

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -130,6 +130,10 @@ impl ThreadScopedOutgoingMessageSender {
         }
     }
 
+    pub(crate) fn connection_ids(&self) -> &[ConnectionId] {
+        self.connection_ids.as_slice()
+    }
+
     pub(crate) async fn send_request(
         &self,
         payload: ServerRequestPayload,

--- a/codex-rs/app-server/src/request_processors/mcp_processor.rs
+++ b/codex-rs/app-server/src/request_processors/mcp_processor.rs
@@ -6,6 +6,7 @@ const MCP_TOOL_THREAD_ID_META_KEY: &str = "threadId";
 pub(crate) struct McpRequestProcessor {
     auth_manager: Arc<AuthManager>,
     thread_manager: Arc<ThreadManager>,
+    thread_state_manager: ThreadStateManager,
     outgoing: Arc<OutgoingMessageSender>,
     config_manager: ConfigManager,
 }
@@ -14,12 +15,14 @@ impl McpRequestProcessor {
     pub(crate) fn new(
         auth_manager: Arc<AuthManager>,
         thread_manager: Arc<ThreadManager>,
+        thread_state_manager: ThreadStateManager,
         outgoing: Arc<OutgoingMessageSender>,
         config_manager: ConfigManager,
     ) -> Self {
         Self {
             auth_manager,
             thread_manager,
+            thread_state_manager,
             outgoing,
             config_manager,
         }
@@ -338,6 +341,12 @@ impl McpRequestProcessor {
         );
         server_names.sort();
         server_names.dedup();
+        let inject_spine_ui = crate::spine_ui::is_enabled();
+        if inject_spine_ui {
+            server_names.push(crate::spine_ui::SERVER_NAME.to_string());
+            server_names.sort();
+            server_names.dedup();
+        }
 
         let total = server_names.len();
         let limit = params.limit.unwrap_or(total as u32).max(1) as usize;
@@ -360,17 +369,26 @@ impl McpRequestProcessor {
 
         let data: Vec<McpServerStatus> = server_names[start..end]
             .iter()
-            .map(|name| McpServerStatus {
-                name: name.clone(),
-                server_info: server_infos.get(name).cloned(),
-                tools: tools_by_server.get(name).cloned().unwrap_or_default(),
-                resources: resources.get(name).cloned().unwrap_or_default(),
-                resource_templates: resource_templates.get(name).cloned().unwrap_or_default(),
-                auth_status: auth_statuses
-                    .get(name)
-                    .cloned()
-                    .unwrap_or(CoreMcpAuthStatus::Unsupported)
-                    .into(),
+            .map(|name| {
+                if inject_spine_ui && name == crate::spine_ui::SERVER_NAME {
+                    crate::spine_ui::server_status(matches!(detail, McpSnapshotDetail::Full))
+                } else {
+                    McpServerStatus {
+                        name: name.clone(),
+                        server_info: server_infos.get(name).cloned(),
+                        tools: tools_by_server.get(name).cloned().unwrap_or_default(),
+                        resources: resources.get(name).cloned().unwrap_or_default(),
+                        resource_templates: resource_templates
+                            .get(name)
+                            .cloned()
+                            .unwrap_or_default(),
+                        auth_status: auth_statuses
+                            .get(name)
+                            .cloned()
+                            .unwrap_or(CoreMcpAuthStatus::Unsupported)
+                            .into(),
+                    }
+                }
             })
             .collect();
 
@@ -388,6 +406,15 @@ impl McpRequestProcessor {
         request_id: &ConnectionRequestId,
         params: McpResourceReadParams,
     ) -> Result<(), JSONRPCErrorError> {
+        if crate::spine_ui::is_enabled()
+            && let Some(response) = crate::spine_ui::read_resource(&params.server, &params.uri)
+        {
+            self.outgoing
+                .send_response(request_id.clone(), response)
+                .await;
+            return Ok(());
+        }
+
         let outgoing = Arc::clone(&self.outgoing);
         let McpResourceReadParams {
             thread_id,
@@ -457,9 +484,22 @@ impl McpRequestProcessor {
         request_id: &ConnectionRequestId,
         params: McpServerToolCallParams,
     ) -> Result<(), JSONRPCErrorError> {
+        let (thread_id, thread) = self.load_thread(&params.thread_id).await?;
+        if crate::spine_ui::is_enabled()
+            && crate::spine_ui::is_internal_tool(&params.server, &params.tool)
+        {
+            let state = self
+                .thread_state_manager
+                .spine_ui_state_for_thread(thread_id)
+                .await;
+            let response = crate::spine_ui::tool_call_response(&params.thread_id, state.as_ref());
+            self.outgoing
+                .send_response(request_id.clone(), response)
+                .await;
+            return Ok(());
+        }
         let outgoing = Arc::clone(&self.outgoing);
         let thread_id = params.thread_id.clone();
-        let (_, thread) = self.load_thread(&thread_id).await?;
         let meta = with_mcp_tool_call_thread_id_meta(params.meta, &thread_id);
         let request_id = request_id.clone();
 

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -1,7 +1,9 @@
 use super::*;
+use crate::spine_ui::SpineUiState;
 use codex_protocol::config_types::MultiAgentMode;
 
 pub(super) const THREAD_UNLOADING_DELAY: Duration = Duration::from_secs(30 * 60);
+const SPINE_UI_TERMINAL_BARRIER_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub(super) struct ListenerTaskContext {
@@ -262,6 +264,10 @@ pub(super) async fn ensure_listener_task_running(
             .register_listener_command_tx(conversation_id, listener_command_tx);
         (listener_command_rx, listener_generation)
     };
+    listener_task_context
+        .thread_state_manager
+        .note_spine_ui_listener_generation(conversation_id, listener_generation)
+        .await;
     let ListenerTaskContext {
         outgoing,
         thread_manager,
@@ -308,6 +314,62 @@ pub(super) async fn ensure_listener_task_running(
                         }
                     };
 
+                    if matches!(&event.msg, EventMsg::TurnStarted(_)) {
+                        thread_state_manager
+                            .note_spine_ui_agent_turn_started(
+                                conversation_id,
+                                listener_generation,
+                            )
+                            .await;
+                    }
+
+                    if crate::spine_ui::is_enabled()
+                        && matches!(&event.msg, EventMsg::TurnComplete(_) | EventMsg::TurnAborted(_))
+                    {
+                        let (agent_states, timed_out) = thread_state_manager
+                            .wait_for_spine_ui_terminal_children(
+                                conversation_id,
+                                &event.id,
+                                SPINE_UI_TERMINAL_BARRIER_TIMEOUT,
+                            )
+                            .await;
+                        if !timed_out.is_empty() {
+                            let child_thread_ids = timed_out
+                                .iter()
+                                .map(|(thread_id, _)| *thread_id)
+                                .collect::<Vec<_>>();
+                            tracing::warn!(
+                                thread_id = %conversation_id,
+                                turn_id = %event.id,
+                                child_thread_ids = ?child_thread_ids,
+                                "Spine UI terminal barrier timed out; using latest child states"
+                            );
+                        }
+                        let mut state = thread_state.lock().await;
+                        if state.live_spine_ui(&event.id).is_some() {
+                            for (child_thread_id, generation, child_state) in agent_states {
+                                if let Some(child_state) = child_state {
+                                    state.record_spine_ui_agent_state(
+                                        child_thread_id,
+                                        generation,
+                                        child_state,
+                                    );
+                                } else {
+                                    state.invalidate_spine_ui_agent_state(
+                                        child_thread_id,
+                                        generation,
+                                    );
+                                }
+                            }
+                            for (child_thread_id, generation) in timed_out {
+                                state.mark_spine_ui_agent_sync_timeout(
+                                    child_thread_id,
+                                    generation,
+                                );
+                            }
+                        }
+                    }
+
                     // Track the event before emitting any typed translations
                     // so thread-local state such as raw event opt-in stays
                     // synchronized with the conversation.
@@ -316,6 +378,25 @@ pub(super) async fn ensure_listener_task_running(
                         thread_state.track_current_turn_event(&event.id, &event.msg);
                         thread_state.experimental_raw_events
                     };
+                    if crate::spine_ui::is_enabled()
+                        && let EventMsg::SpineSpawnProgress(progress) = &event.msg
+                    {
+                        thread_state_manager
+                            .register_spine_ui_spawn_progress(
+                                conversation_id,
+                                &event.id,
+                                progress,
+                            )
+                            .await;
+                    }
+                    if crate::spine_ui::is_enabled()
+                        && matches!(&event.msg, EventMsg::ThreadRolledBack(_))
+                    {
+                        thread_state.lock().await.reset_spine_ui_after_rollback();
+                        thread_state_manager
+                            .clear_all_spine_ui_routes_for_thread(conversation_id)
+                            .await;
+                    }
                     if matches!(&event.msg, EventMsg::RawResponseItem(_)) && !raw_events_enabled {
                         continue;
                     }
@@ -340,6 +421,30 @@ pub(super) async fn ensure_listener_task_running(
                         fallback_model_provider.clone(),
                     )
                     .await;
+                    if matches!(
+                        &event.msg,
+                        EventMsg::TurnStarted(_)
+                            | EventMsg::SpineTreeUpdate(_)
+                            | EventMsg::SpineSpawnProgress(_)
+                            | EventMsg::TurnComplete(_)
+                            | EventMsg::TurnAborted(_)
+                    ) {
+                        thread_state_manager
+                            .queue_spine_ui_agent_state(conversation_id)
+                            .await;
+                    }
+                    if matches!(&event.msg, EventMsg::TurnComplete(_) | EventMsg::TurnAborted(_)) {
+                        thread_state_manager
+                            .acknowledge_spine_ui_agent_terminal(
+                                conversation_id,
+                                listener_generation,
+                                &event.id,
+                            )
+                            .await;
+                        thread_state_manager
+                            .clear_spine_ui_parent_routes(conversation_id, &event.id)
+                            .await;
+                    }
                 }
                 unloading_watchers_open = unloading_state.wait_for_unloading_trigger() => {
                     if !unloading_watchers_open {
@@ -377,10 +482,20 @@ pub(super) async fn ensure_listener_task_running(
             }
         }
 
-        let mut thread_state = thread_state.lock().await;
-        if thread_state.listener_generation == listener_generation {
-            thread_state_manager.unregister_listener_command_tx(conversation_id);
-            thread_state.clear_listener();
+        let listener_was_current = {
+            let mut thread_state = thread_state.lock().await;
+            if thread_state.listener_generation == listener_generation {
+                thread_state_manager.unregister_listener_command_tx(conversation_id);
+                thread_state.clear_listener();
+                true
+            } else {
+                false
+            }
+        };
+        if listener_was_current {
+            thread_state_manager
+                .clear_spine_ui_routes_for_listener_exit(conversation_id, listener_generation)
+                .await;
         }
     });
     Ok(())
@@ -508,6 +623,139 @@ pub(super) async fn handle_thread_listener_command(
             )
             .await;
             let _ = completion_tx.send(());
+        }
+        ThreadListenerCommand::ForwardSpineUiAgentState {
+            child_thread_id,
+            parent_turn_id,
+            generation,
+            state: child_state,
+            terminal,
+        } => {
+            if !thread_state_manager
+                .spine_ui_route_is_current(
+                    child_thread_id,
+                    conversation_id,
+                    &parent_turn_id,
+                    generation,
+                )
+                .await
+            {
+                return;
+            }
+            let forwarded_revision = child_state.as_ref().map(SpineUiState::revision);
+            let (spine_ui, late_terminal_refresh) = {
+                let mut state = thread_state.lock().await;
+                if state.live_spine_ui(&parent_turn_id).is_some() {
+                    let changed = child_state.is_some_and(|child_state| {
+                        state.record_spine_ui_agent_state(child_thread_id, generation, child_state)
+                    });
+                    (
+                        changed
+                            .then(|| state.live_spine_ui(&parent_turn_id).cloned())
+                            .flatten(),
+                        None,
+                    )
+                } else if terminal {
+                    (
+                        None,
+                        state.record_completed_spine_ui_agent_terminal(
+                            &parent_turn_id,
+                            child_thread_id,
+                            generation,
+                            child_state,
+                        ),
+                    )
+                } else {
+                    (None, None)
+                }
+            };
+            if let Some(spine_ui) = spine_ui {
+                let connection_ids = thread_state_manager
+                    .subscribed_connection_ids(conversation_id)
+                    .await;
+                let outgoing = ThreadScopedOutgoingMessageSender::new(
+                    outgoing.clone(),
+                    connection_ids,
+                    conversation_id,
+                );
+                if let Some(notification) = crate::spine_ui::snapshot_started_notification(
+                    &conversation_id.to_string(),
+                    &parent_turn_id,
+                    &spine_ui,
+                ) {
+                    outgoing
+                        .send_server_notification(ServerNotification::ItemStarted(notification))
+                        .await;
+                }
+                thread_state_manager
+                    .queue_spine_ui_agent_state(conversation_id)
+                    .await;
+            }
+            if let Some(refresh) = late_terminal_refresh {
+                if let Some(notification) = crate::spine_ui::snapshot_completed_notification(
+                    &conversation_id.to_string(),
+                    &parent_turn_id,
+                    &refresh.state,
+                ) {
+                    let mut connection_ids = thread_state_manager
+                        .subscribed_connection_ids(conversation_id)
+                        .await;
+                    connection_ids
+                        .retain(|connection_id| refresh.connection_ids.contains(connection_id));
+                    ThreadScopedOutgoingMessageSender::new(
+                        outgoing.clone(),
+                        connection_ids,
+                        conversation_id,
+                    )
+                    .send_server_notification(ServerNotification::ItemCompleted(notification))
+                    .await;
+                }
+                thread_state_manager
+                    .queue_spine_ui_agent_terminal_refresh(conversation_id)
+                    .await;
+            }
+            if !terminal && let Some(forwarded_revision) = forwarded_revision {
+                thread_state_manager
+                    .complete_spine_ui_agent_state_forward(
+                        child_thread_id,
+                        conversation_id,
+                        &parent_turn_id,
+                        generation,
+                        forwarded_revision,
+                    )
+                    .await;
+            }
+            if terminal {
+                thread_state_manager
+                    .complete_spine_ui_late_terminal(
+                        child_thread_id,
+                        conversation_id,
+                        &parent_turn_id,
+                        generation,
+                    )
+                    .await;
+                thread_state_manager
+                    .clear_spine_ui_parent_routes(conversation_id, &parent_turn_id)
+                    .await;
+            }
+        }
+        ThreadListenerCommand::EmitSpineUiInvalidation { turn_id, state } => {
+            if let Some(notification) = crate::spine_ui::snapshot_started_notification(
+                &conversation_id.to_string(),
+                &turn_id,
+                &state,
+            ) {
+                let connection_ids = thread_state_manager
+                    .subscribed_connection_ids(conversation_id)
+                    .await;
+                ThreadScopedOutgoingMessageSender::new(
+                    outgoing.clone(),
+                    connection_ids,
+                    conversation_id,
+                )
+                .send_server_notification(ServerNotification::ItemStarted(notification))
+                .await;
+            }
         }
     }
 }

--- a/codex-rs/app-server/src/spine_ui.rs
+++ b/codex-rs/app-server/src/spine_ui.rs
@@ -1,0 +1,423 @@
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::SpineSpawnOutcome;
+use codex_protocol::protocol::SpineSpawnProgressEvent;
+use codex_protocol::protocol::SpineSpawnTaskProgress;
+use codex_protocol::protocol::SpineTreeUpdateEvent;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+mod mcp;
+mod render;
+
+pub(crate) use mcp::is_enabled;
+pub(crate) use mcp::is_internal_tool;
+pub(crate) use mcp::is_tree_tool_call;
+pub(crate) use mcp::read_resource;
+pub(crate) use mcp::server_status;
+pub(crate) use mcp::snapshot_completed_notification;
+pub(crate) use mcp::snapshot_started_notification;
+pub(crate) use mcp::tool_call_response;
+
+pub(crate) const ENABLE_ENV: &str = "CODEX_SPINE_APP_UI";
+pub(crate) const SERVER_NAME: &str = "__codex_internal_spine_tree_ui__";
+pub(crate) const TOOL_NAME: &str = "spine_tree";
+pub(crate) const RESOURCE_URI: &str = "ui://spine/tree.html";
+const ITEM_ID_PREFIX: &str = "spine-ui-";
+const RESOURCE_MIME_TYPE: &str = "text/html;profile=mcp-app";
+const RESOURCE_HTML: &str = include_str!("spine_ui/tree.html");
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SpineUiSpawnTask {
+    progress: SpineSpawnTaskProgress,
+    result_node_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SpineUiSpawnCall {
+    call_id: String,
+    parent_node_id: Option<String>,
+    tasks: Vec<SpineUiSpawnTask>,
+}
+
+#[derive(Clone, Debug)]
+struct SpineUiAgentState {
+    generation: u64,
+    state: SpineUiState,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SpineUiState {
+    revision: u64,
+    started_at_ms: Option<i64>,
+    completed_at_ms: Option<i64>,
+    snapshot: Option<SpineTreeUpdateEvent>,
+    spawn_calls: Vec<SpineUiSpawnCall>,
+    settled_spawn_call_ids: HashSet<String>,
+    agent_subtrees: HashMap<ThreadId, SpineUiAgentState>,
+    invalidated_agent_generations: HashMap<ThreadId, u64>,
+    agent_sync_timeout_generations: HashMap<ThreadId, u64>,
+}
+
+impl SpineUiState {
+    pub(crate) fn record_snapshot(&mut self, snapshot: SpineTreeUpdateEvent) -> bool {
+        if let Some(current) = self.snapshot.as_ref()
+            && (snapshot.snapshot_seq < current.snapshot_seq
+                || (snapshot.snapshot_seq == current.snapshot_seq && snapshot == *current))
+        {
+            return false;
+        }
+        for call in &mut self.spawn_calls {
+            if call.parent_node_id.is_none() {
+                call.parent_node_id = Some(snapshot.active_node_id.clone());
+            }
+        }
+        self.settled_spawn_call_ids
+            .extend(snapshot.settled_spawn_call_ids.iter().cloned());
+        self.reconcile_spawn_result_nodes(&snapshot);
+        let visible_agent_thread_ids = self
+            .spawn_calls
+            .iter()
+            .flat_map(|call| call.tasks.iter().map(|task| task.progress.thread_id))
+            .collect::<HashSet<_>>();
+        self.agent_subtrees
+            .retain(|thread_id, _| visible_agent_thread_ids.contains(thread_id));
+        self.invalidated_agent_generations
+            .retain(|thread_id, _| visible_agent_thread_ids.contains(thread_id));
+        self.agent_sync_timeout_generations
+            .retain(|thread_id, _| visible_agent_thread_ids.contains(thread_id));
+        self.settled_spawn_call_ids
+            .retain(|call_id| self.spawn_calls.iter().any(|call| &call.call_id == call_id));
+        self.snapshot = Some(snapshot);
+        self.started_at_ms.get_or_insert_with(now_unix_timestamp_ms);
+        self.bump_revision();
+        true
+    }
+
+    pub(crate) fn record_spawn_progress(&mut self, progress: SpineSpawnProgressEvent) -> bool {
+        if self.settled_spawn_call_ids.contains(&progress.call_id) {
+            return false;
+        }
+        let parent_node_id = self
+            .snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.active_node_id.clone());
+        if let Some(existing) = self
+            .spawn_calls
+            .iter_mut()
+            .find(|call| call.call_id == progress.call_id)
+        {
+            let result_node_ids = existing
+                .tasks
+                .iter()
+                .map(|task| (task.progress.ordinal, task.result_node_id.clone()))
+                .collect::<HashMap<_, _>>();
+            let previous = existing.tasks.clone();
+            existing.tasks = progress
+                .tasks
+                .into_iter()
+                .map(|mut progress| {
+                    if let Some(old) = previous
+                        .iter()
+                        .find(|task| task.progress.ordinal == progress.ordinal)
+                        && (status_rank(&old.progress.status) >= 2
+                            || status_rank(&old.progress.status) > status_rank(&progress.status))
+                    {
+                        progress.status = old.progress.status.clone();
+                    }
+                    SpineUiSpawnTask {
+                        result_node_id: result_node_ids.get(&progress.ordinal).cloned().flatten(),
+                        progress,
+                    }
+                })
+                .collect();
+            if existing.parent_node_id.is_none() {
+                existing.parent_node_id = parent_node_id;
+            }
+        } else {
+            self.spawn_calls.push(SpineUiSpawnCall {
+                call_id: progress.call_id,
+                parent_node_id,
+                tasks: progress
+                    .tasks
+                    .into_iter()
+                    .map(|progress| SpineUiSpawnTask {
+                        progress,
+                        result_node_id: None,
+                    })
+                    .collect(),
+            });
+        }
+        self.started_at_ms.get_or_insert_with(now_unix_timestamp_ms);
+        self.bump_revision();
+        true
+    }
+
+    pub(crate) fn record_agent_state(
+        &mut self,
+        thread_id: ThreadId,
+        generation: u64,
+        state: SpineUiState,
+    ) -> bool {
+        let is_known_agent = self.spawn_calls.iter().any(|call| {
+            call.tasks
+                .iter()
+                .any(|task| task.progress.thread_id == thread_id)
+        });
+        if !is_known_agent
+            || self
+                .invalidated_agent_generations
+                .get(&thread_id)
+                .is_some_and(|invalidated| generation <= *invalidated)
+            || self.agent_subtrees.get(&thread_id).is_some_and(|current| {
+                generation < current.generation
+                    || (generation == current.generation
+                        && state.revision <= current.state.revision)
+            })
+        {
+            return false;
+        }
+        for call in &mut self.spawn_calls {
+            if let Some(task) = call
+                .tasks
+                .iter_mut()
+                .find(|task| task.progress.thread_id == thread_id)
+                && matches!(
+                    task.progress.status,
+                    codex_protocol::protocol::AgentStatus::PendingInit
+                )
+            {
+                task.progress.status = codex_protocol::protocol::AgentStatus::Running;
+            }
+        }
+        self.agent_subtrees
+            .insert(thread_id, SpineUiAgentState { generation, state });
+        if self
+            .agent_sync_timeout_generations
+            .get(&thread_id)
+            .is_some_and(|timed_out| generation > *timed_out)
+        {
+            self.agent_sync_timeout_generations.remove(&thread_id);
+        }
+        self.bump_revision();
+        true
+    }
+
+    pub(crate) fn mark_agent_sync_timeout(&mut self, thread_id: ThreadId, generation: u64) -> bool {
+        let is_known_agent = self.spawn_calls.iter().any(|call| {
+            call.tasks
+                .iter()
+                .any(|task| task.progress.thread_id == thread_id)
+        });
+        if !is_known_agent
+            || self
+                .invalidated_agent_generations
+                .get(&thread_id)
+                .is_some_and(|invalidated| generation <= *invalidated)
+            || self
+                .agent_subtrees
+                .get(&thread_id)
+                .is_some_and(|current| generation < current.generation)
+            || self.agent_sync_timeout_generations.get(&thread_id) == Some(&generation)
+        {
+            return false;
+        }
+        self.agent_sync_timeout_generations
+            .insert(thread_id, generation);
+        self.bump_revision();
+        true
+    }
+
+    pub(crate) fn clear_agent_sync_timeout(
+        &mut self,
+        thread_id: ThreadId,
+        generation: u64,
+    ) -> bool {
+        if self.agent_sync_timeout_generations.get(&thread_id) != Some(&generation) {
+            return false;
+        }
+        self.agent_sync_timeout_generations.remove(&thread_id);
+        self.bump_revision();
+        true
+    }
+
+    pub(crate) fn remove_agent_state(&mut self, thread_id: ThreadId, generation: u64) -> bool {
+        self.invalidated_agent_generations
+            .entry(thread_id)
+            .and_modify(|invalidated| *invalidated = (*invalidated).max(generation))
+            .or_insert(generation);
+        let should_remove_subtree = self
+            .agent_subtrees
+            .get(&thread_id)
+            .is_some_and(|current| current.generation <= generation);
+        let should_remove_timeout = self
+            .agent_sync_timeout_generations
+            .get(&thread_id)
+            .is_some_and(|current| *current <= generation);
+        if !should_remove_subtree && !should_remove_timeout {
+            return false;
+        }
+        if should_remove_subtree {
+            self.agent_subtrees.remove(&thread_id);
+        }
+        if should_remove_timeout {
+            self.agent_sync_timeout_generations.remove(&thread_id);
+        }
+        self.bump_revision();
+        true
+    }
+
+    pub(crate) fn latest_snapshot(&self) -> Option<&SpineTreeUpdateEvent> {
+        self.snapshot.as_ref()
+    }
+
+    pub(crate) fn filtered_for_parent(&self, baseline_node_ids: &HashSet<String>) -> Self {
+        let mut filtered = self.clone();
+        if let Some(snapshot) = filtered.snapshot.as_mut() {
+            snapshot
+                .nodes
+                .retain(|node| !baseline_node_ids.contains(&node.node_id));
+            if !snapshot
+                .nodes
+                .iter()
+                .any(|node| node.node_id == snapshot.active_node_id)
+                && let Some(node) = snapshot.nodes.last()
+            {
+                snapshot.active_node_id = node.node_id.clone();
+            }
+        }
+        for call in &mut filtered.spawn_calls {
+            if call
+                .parent_node_id
+                .as_ref()
+                .is_some_and(|node_id| baseline_node_ids.contains(node_id))
+            {
+                call.parent_node_id = None;
+            }
+        }
+        filtered
+    }
+
+    pub(crate) fn carry_forward(&self) -> Self {
+        Self {
+            revision: self.revision,
+            started_at_ms: None,
+            completed_at_ms: None,
+            snapshot: None,
+            spawn_calls: self.spawn_calls.clone(),
+            settled_spawn_call_ids: self.settled_spawn_call_ids.clone(),
+            agent_subtrees: self.agent_subtrees.clone(),
+            invalidated_agent_generations: self.invalidated_agent_generations.clone(),
+            agent_sync_timeout_generations: self.agent_sync_timeout_generations.clone(),
+        }
+    }
+
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub(crate) fn has_agent_sync_timeout(&self) -> bool {
+        !self.agent_sync_timeout_generations.is_empty()
+            || self
+                .agent_subtrees
+                .values()
+                .any(|agent| agent.state.has_agent_sync_timeout())
+    }
+
+    pub(crate) fn set_revision(&mut self, revision: u64) {
+        self.revision = revision;
+    }
+
+    pub(crate) fn mark_completed(&mut self) {
+        self.completed_at_ms
+            .get_or_insert_with(now_unix_timestamp_ms);
+    }
+
+    pub(crate) fn started_at_ms(&self) -> Option<i64> {
+        self.started_at_ms
+    }
+
+    pub(crate) fn completed_at_ms(&self) -> Option<i64> {
+        self.completed_at_ms
+    }
+
+    pub(crate) fn structured_content(&self) -> Option<serde_json::Value> {
+        render::structured_content(self)
+    }
+
+    fn reconcile_spawn_result_nodes(&mut self, snapshot: &SpineTreeUpdateEvent) {
+        let mut claimed_node_ids = self
+            .spawn_calls
+            .iter()
+            .flat_map(|call| call.tasks.iter())
+            .filter_map(|task| task.result_node_id.clone())
+            .collect::<HashSet<_>>();
+
+        for call in &mut self.spawn_calls {
+            if !self.settled_spawn_call_ids.contains(&call.call_id) {
+                continue;
+            }
+            for task in &mut call.tasks {
+                if task.result_node_id.is_some() {
+                    continue;
+                }
+                let Some(node) = snapshot.nodes.iter().find(|node| {
+                    node.spawn_outcome.is_some()
+                        && node.parent_id == call.parent_node_id
+                        && node.summary.as_deref() == Some(task.progress.summary.as_str())
+                        && !claimed_node_ids.contains(&node.node_id)
+                }) else {
+                    continue;
+                };
+                task.progress.status = match node.spawn_outcome {
+                    Some(SpineSpawnOutcome::Completed) => {
+                        codex_protocol::protocol::AgentStatus::Completed(None)
+                    }
+                    Some(SpineSpawnOutcome::Errored) => {
+                        codex_protocol::protocol::AgentStatus::Errored(
+                            node.memory_summary
+                                .clone()
+                                .unwrap_or_else(|| "Agent failed".to_string()),
+                        )
+                    }
+                    Some(SpineSpawnOutcome::Aborted) => {
+                        codex_protocol::protocol::AgentStatus::Shutdown
+                    }
+                    None => continue,
+                };
+                task.result_node_id = Some(node.node_id.clone());
+                claimed_node_ids.insert(node.node_id.clone());
+            }
+        }
+    }
+
+    fn bump_revision(&mut self) {
+        self.revision = self.revision.saturating_add(1);
+    }
+}
+
+fn status_rank(status: &codex_protocol::protocol::AgentStatus) -> u8 {
+    match status {
+        codex_protocol::protocol::AgentStatus::PendingInit => 0,
+        codex_protocol::protocol::AgentStatus::Running => 1,
+        codex_protocol::protocol::AgentStatus::Interrupted => 2,
+        codex_protocol::protocol::AgentStatus::Completed(_)
+        | codex_protocol::protocol::AgentStatus::Errored(_)
+        | codex_protocol::protocol::AgentStatus::Shutdown
+        | codex_protocol::protocol::AgentStatus::NotFound => 3,
+    }
+}
+
+fn now_unix_timestamp_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+#[path = "spine_ui_tests.rs"]
+mod tests;

--- a/codex-rs/app-server/src/spine_ui/mcp.rs
+++ b/codex-rs/app-server/src/spine_ui/mcp.rs
@@ -1,0 +1,257 @@
+use super::ENABLE_ENV;
+use super::ITEM_ID_PREFIX;
+use super::RESOURCE_HTML;
+use super::RESOURCE_MIME_TYPE;
+use super::RESOURCE_URI;
+use super::SERVER_NAME;
+use super::SpineUiState;
+use super::TOOL_NAME;
+use codex_app_server_protocol::ItemCompletedNotification;
+use codex_app_server_protocol::ItemStartedNotification;
+use codex_app_server_protocol::McpAuthStatus;
+use codex_app_server_protocol::McpResourceContent;
+use codex_app_server_protocol::McpResourceReadResponse;
+use codex_app_server_protocol::McpServerStatus;
+use codex_app_server_protocol::McpServerToolCallResponse;
+use codex_app_server_protocol::McpToolCallStatus;
+use codex_app_server_protocol::ThreadItem;
+use codex_protocol::items::McpToolCallItem;
+use codex_protocol::items::McpToolCallStatus as CoreMcpToolCallStatus;
+use codex_protocol::items::TurnItem as CoreTurnItem;
+use codex_protocol::mcp::CallToolResult;
+use codex_protocol::mcp::McpServerInfo;
+use codex_protocol::mcp::Resource;
+use codex_protocol::mcp::Tool;
+use codex_protocol::models::ResponseItem;
+use serde_json::json;
+use std::collections::HashMap;
+
+pub(crate) fn is_enabled() -> bool {
+    enabled_from_env_value(std::env::var(ENABLE_ENV).ok().as_deref())
+}
+
+fn enabled_from_env_value(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "on"
+        )
+    })
+}
+
+pub(crate) fn is_tree_tool_call(item: &ResponseItem) -> bool {
+    let ResponseItem::FunctionCall {
+        name, namespace, ..
+    } = item
+    else {
+        return false;
+    };
+    let tool = match namespace.as_deref() {
+        Some("spine") => name.as_str(),
+        None => name.strip_prefix("spine.").unwrap_or_default(),
+        Some(_) => return false,
+    };
+    matches!(tool, "open" | "next" | "close" | "spawn")
+}
+
+pub(crate) fn read_resource(server: &str, uri: &str) -> Option<McpResourceReadResponse> {
+    (server == SERVER_NAME && uri == RESOURCE_URI).then(|| McpResourceReadResponse {
+        contents: vec![McpResourceContent::Text {
+            uri: uri.to_string(),
+            mime_type: Some(RESOURCE_MIME_TYPE.to_string()),
+            text: RESOURCE_HTML.to_string(),
+            meta: Some(json!({
+                "ui": {
+                    "prefersBorder": true,
+                    "csp": {
+                        "connectDomains": [],
+                        "resourceDomains": []
+                    }
+                },
+                "openai/widgetHeightHint": 1,
+                "openai/widgetMinFrameHeight": 1
+            })),
+        }],
+    })
+}
+
+pub(crate) fn is_internal_tool(server: &str, tool: &str) -> bool {
+    server == SERVER_NAME && tool == TOOL_NAME
+}
+
+pub(crate) fn tool_call_response(
+    thread_id: &str,
+    state: Option<&SpineUiState>,
+) -> McpServerToolCallResponse {
+    let Some(structured_content) = state.and_then(SpineUiState::structured_content) else {
+        return McpServerToolCallResponse {
+            content: vec![json!({
+                "type": "text",
+                "text": "No Spine Tree is active for this thread."
+            })],
+            structured_content: None,
+            is_error: Some(true),
+            meta: None,
+        };
+    };
+    McpServerToolCallResponse {
+        content: vec![json!({
+            "type": "text",
+            "text": "Spine Tree"
+        })],
+        structured_content: Some(structured_content),
+        is_error: Some(false),
+        meta: Some(json!({
+            "openai/widgetSessionId": format!("spine-ui-tool-{thread_id}")
+        })),
+    }
+}
+
+pub(crate) fn server_status(include_resources: bool) -> McpServerStatus {
+    let tool = Tool {
+        name: TOOL_NAME.to_string(),
+        title: Some("Spine Tree".to_string()),
+        description: Some(
+            "Host-managed read-only view of the current Spine task tree.".to_string(),
+        ),
+        input_schema: json!({"type": "object", "properties": {}, "additionalProperties": false}),
+        output_schema: None,
+        annotations: Some(json!({
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "openWorldHint": false
+        })),
+        icons: None,
+        meta: Some(json!({"ui": {"resourceUri": RESOURCE_URI}})),
+    };
+    McpServerStatus {
+        name: SERVER_NAME.to_string(),
+        server_info: Some(McpServerInfo {
+            name: SERVER_NAME.to_string(),
+            title: Some("Spine UI".to_string()),
+            version: "1".to_string(),
+            description: Some("Read-only Spine task tree UI.".to_string()),
+            icons: None,
+            website_url: None,
+        }),
+        tools: HashMap::from([(tool.name.clone(), tool)]),
+        resources: include_resources
+            .then(|| registered_resource(RESOURCE_URI, "spine-tree", "Spine Tree"))
+            .into_iter()
+            .collect(),
+        resource_templates: Vec::new(),
+        auth_status: McpAuthStatus::Unsupported,
+    }
+}
+
+fn registered_resource(uri: &str, name: &str, title: &str) -> Resource {
+    Resource {
+        annotations: None,
+        description: Some("Spine task tree component".to_string()),
+        mime_type: Some(RESOURCE_MIME_TYPE.to_string()),
+        name: name.to_string(),
+        size: None,
+        title: Some(title.to_string()),
+        uri: uri.to_string(),
+        icons: None,
+        meta: None,
+    }
+}
+
+pub(crate) fn snapshot_started_notification(
+    thread_id: &str,
+    turn_id: &str,
+    state: &SpineUiState,
+) -> Option<ItemStartedNotification> {
+    Some(ItemStartedNotification {
+        item: snapshot_item(turn_id, state, McpToolCallStatus::InProgress)?,
+        thread_id: thread_id.to_string(),
+        turn_id: turn_id.to_string(),
+        started_at_ms: state.started_at_ms()?,
+    })
+}
+
+pub(crate) fn snapshot_completed_notification(
+    thread_id: &str,
+    turn_id: &str,
+    state: &SpineUiState,
+) -> Option<ItemCompletedNotification> {
+    Some(ItemCompletedNotification {
+        item: snapshot_item(turn_id, state, McpToolCallStatus::Completed)?,
+        thread_id: thread_id.to_string(),
+        turn_id: turn_id.to_string(),
+        completed_at_ms: state.completed_at_ms()?,
+    })
+}
+
+fn snapshot_item(
+    turn_id: &str,
+    state: &SpineUiState,
+    status: McpToolCallStatus,
+) -> Option<ThreadItem> {
+    Some(ThreadItem::from(snapshot_core_item(
+        turn_id,
+        state,
+        match status {
+            McpToolCallStatus::InProgress => CoreMcpToolCallStatus::InProgress,
+            McpToolCallStatus::Completed => CoreMcpToolCallStatus::Completed,
+            McpToolCallStatus::Failed => CoreMcpToolCallStatus::Failed,
+        },
+    )?))
+}
+
+fn snapshot_core_item(
+    turn_id: &str,
+    state: &SpineUiState,
+    status: CoreMcpToolCallStatus,
+) -> Option<CoreTurnItem> {
+    let structured_content = state.structured_content()?;
+    let snapshot_seq = state.snapshot.as_ref()?.snapshot_seq;
+    // Codex supersedes older widgets that share a server/resource unless the host
+    // gives each independently mounted turn a stable widget session.
+    let item_id = format!("{ITEM_ID_PREFIX}{turn_id}");
+    Some(CoreTurnItem::McpToolCall(McpToolCallItem {
+        id: item_id.clone(),
+        server: SERVER_NAME.to_string(),
+        tool: TOOL_NAME.to_string(),
+        status,
+        arguments: json!({}),
+        connector_id: Some(SERVER_NAME.to_string()),
+        mcp_app_resource_uri: Some(RESOURCE_URI.to_string()),
+        link_id: None,
+        app_name: Some("Spine UI".to_string()),
+        template_id: None,
+        action_name: Some(TOOL_NAME.to_string()),
+        plugin_id: None,
+        result: Some(CallToolResult {
+            content: vec![json!({
+                "type": "text",
+                "text": format!("Spine snapshot {snapshot_seq}"),
+            })],
+            structured_content: Some(structured_content),
+            is_error: Some(false),
+            meta: Some(json!({
+                "ui/resourceUri": RESOURCE_URI,
+                "openai/widgetSessionId": item_id,
+            })),
+        }),
+        error: None,
+        duration: None,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::enabled_from_env_value;
+
+    #[test]
+    fn enable_env_parser_is_strict() {
+        for enabled in ["1", "true", "TRUE", " on "] {
+            assert!(enabled_from_env_value(Some(enabled)), "{enabled}");
+        }
+        for disabled in ["", "0", "false", "off", "yes", "enabled"] {
+            assert!(!enabled_from_env_value(Some(disabled)), "{disabled}");
+        }
+        assert!(!enabled_from_env_value(None));
+    }
+}

--- a/codex-rs/app-server/src/spine_ui/render.rs
+++ b/codex-rs/app-server/src/spine_ui/render.rs
@@ -1,0 +1,160 @@
+use super::SpineUiState;
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::AgentStatus;
+use codex_protocol::protocol::SpineSpawnOutcome;
+use codex_protocol::protocol::SpineTreeNodeKind;
+use codex_protocol::protocol::SpineTreeNodeStatus;
+use serde::Serialize;
+use serde_json::json;
+use std::collections::HashSet;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SpineUiAgentSubtree {
+    thread_id: ThreadId,
+    #[serde(flatten)]
+    content: serde_json::Value,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SpineUiRenderSnapshot<'a> {
+    active_node_id: &'a str,
+    nodes: Vec<SpineUiRenderNode<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SpineUiRenderNode<'a> {
+    node_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_id: Option<&'a str>,
+    kind: SpineTreeNodeKind,
+    status: SpineTreeNodeStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spawn_outcome: Option<SpineSpawnOutcome>,
+    start: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SpineUiRenderSpawnCall<'a> {
+    call_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_node_id: Option<&'a str>,
+    tasks: Vec<SpineUiRenderSpawnTask<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SpineUiRenderSpawnTask<'a> {
+    ordinal: u32,
+    summary: &'a str,
+    thread_id: ThreadId,
+    status: SpineUiRenderAgentStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result_node_id: Option<&'a str>,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SpineUiRenderAgentStatus {
+    Pending,
+    Running,
+    Interrupted,
+    Completed,
+    Error,
+    Shutdown,
+    NotFound,
+}
+
+impl From<&AgentStatus> for SpineUiRenderAgentStatus {
+    fn from(status: &AgentStatus) -> Self {
+        match status {
+            AgentStatus::PendingInit => Self::Pending,
+            AgentStatus::Running => Self::Running,
+            AgentStatus::Interrupted => Self::Interrupted,
+            AgentStatus::Completed(_) => Self::Completed,
+            AgentStatus::Errored(_) => Self::Error,
+            AgentStatus::Shutdown => Self::Shutdown,
+            AgentStatus::NotFound => Self::NotFound,
+        }
+    }
+}
+
+pub(super) fn structured_content(state: &SpineUiState) -> Option<serde_json::Value> {
+    let snapshot = state.snapshot.as_ref()?;
+    let visible_node_ids = snapshot
+        .nodes
+        .iter()
+        .map(|node| node.node_id.as_str())
+        .collect::<HashSet<_>>();
+    let mut seen_agent_threads = HashSet::new();
+    let agent_subtrees = state
+        .spawn_calls
+        .iter()
+        .flat_map(|call| call.tasks.iter())
+        .filter_map(|task| {
+            let thread_id = task.progress.thread_id;
+            let child_state = &state.agent_subtrees.get(&thread_id)?.state;
+            let content = structured_content(child_state)?;
+            seen_agent_threads
+                .insert(thread_id)
+                .then_some(SpineUiAgentSubtree { thread_id, content })
+        })
+        .collect::<Vec<_>>();
+    let snapshot = SpineUiRenderSnapshot {
+        active_node_id: &snapshot.active_node_id,
+        nodes: snapshot
+            .nodes
+            .iter()
+            .map(|node| SpineUiRenderNode {
+                node_id: &node.node_id,
+                parent_id: node.parent_id.as_deref(),
+                kind: node.kind,
+                status: node.status,
+                summary: node.summary.as_deref(),
+                spawn_outcome: node.spawn_outcome,
+                start: node.start,
+            })
+            .collect(),
+    };
+    let spawn_calls = state
+        .spawn_calls
+        .iter()
+        .map(|call| SpineUiRenderSpawnCall {
+            call_id: &call.call_id,
+            parent_node_id: call
+                .parent_node_id
+                .as_deref()
+                .filter(|parent_node_id| visible_node_ids.contains(parent_node_id)),
+            tasks: call
+                .tasks
+                .iter()
+                .map(|task| SpineUiRenderSpawnTask {
+                    ordinal: task.progress.ordinal,
+                    summary: &task.progress.summary,
+                    thread_id: task.progress.thread_id,
+                    status: if state
+                        .agent_sync_timeout_generations
+                        .contains_key(&task.progress.thread_id)
+                    {
+                        SpineUiRenderAgentStatus::Error
+                    } else {
+                        (&task.progress.status).into()
+                    },
+                    result_node_id: task.result_node_id.as_deref(),
+                })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    Some(json!({
+        "schemaVersion": 1,
+        "uiRevision": state.revision,
+        "snapshot": snapshot,
+        "spawnCalls": spawn_calls,
+        "agentSubtrees": agent_subtrees,
+    }))
+}

--- a/codex-rs/app-server/src/spine_ui/tree.html
+++ b/codex-rs/app-server/src/spine_ui/tree.html
@@ -1,0 +1,646 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:">
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --surface-hover: #eff2f5;
+      --text: #202320;
+      --text-soft: #5f655f;
+      --text-faint: #838983;
+      --border: #daddd8;
+      --border-strong: #c3c8c2;
+      --rail: #cbd0ca;
+      --active: #0969da;
+      --active-strong: #0550ae;
+      --current-row: #e1edfa;
+      --complete: #1a7f37;
+      --archive: #7057a4;
+      --error: #cf222e;
+      --warning: #9a6700;
+      --focus: #0969da;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color-scheme: dark;
+        --surface-hover: #303236;
+        --text: #f1f3ef;
+        --text-soft: #b3b9b2;
+        --text-faint: #8b928b;
+        --border: #393e39;
+        --border-strong: #515751;
+        --rail: #4a504a;
+        --active: #4493f8;
+        --active-strong: #79c0ff;
+        --current-row: #243341;
+        --complete: #3fb950;
+        --archive: #c4b5fd;
+        --error: #f85149;
+        --warning: #d29922;
+        --focus: #4493f8;
+      }
+    }
+
+    * { box-sizing: border-box; }
+    html, body { min-width: 0; margin: 0; overflow: hidden; background: transparent; color: var(--text); }
+    body { min-height: 0; padding: 0; }
+    button { color: inherit; font: inherit; letter-spacing: 0; }
+    [hidden] { display: none !important; }
+
+    .lucide {
+      display: block;
+      width: 16px;
+      height: 16px;
+      fill: none;
+      stroke: currentColor;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-width: 2;
+    }
+
+    .spine-card {
+      container-type: inline-size;
+      width: 100%;
+      max-height: 720px;
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-color: var(--border-strong) transparent;
+      scrollbar-width: thin;
+      background: transparent;
+    }
+
+    .spine-card::-webkit-scrollbar { width: 8px; }
+    .spine-card::-webkit-scrollbar-track { background: transparent; }
+    .spine-card::-webkit-scrollbar-thumb {
+      border: 2px solid transparent;
+      border-radius: 8px;
+      background: var(--border-strong);
+      background-clip: padding-box;
+    }
+
+    .card-body { padding: 6px; }
+    .path-list, .path-children { margin: 0; padding: 0; list-style: none; }
+    .path-children { margin-left: 6px; padding-left: 13px; }
+    .path-item { position: relative; min-width: 0; }
+    .path-children > .path-item::before {
+      position: absolute;
+      top: 0;
+      left: -13px;
+      width: 12px;
+      height: 14px;
+      border-bottom: 1px solid var(--rail);
+      border-left: 1px solid var(--rail);
+      content: "";
+    }
+    .path-children > .path-item:not(:last-child)::after {
+      position: absolute;
+      top: 14px;
+      bottom: 0;
+      left: -13px;
+      border-left: 1px solid var(--rail);
+      content: "";
+    }
+
+    .node-row, .agent-row, .drawer-control {
+      position: relative;
+      z-index: 1;
+      border: 0;
+      border-radius: 5px;
+      background: transparent;
+      color: inherit;
+      text-align: left;
+    }
+    .node-row, .agent-row {
+      display: grid;
+      width: 100%;
+      min-height: 28px;
+      grid-template-columns: 14px 18px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 6px;
+      margin: 0;
+      padding: 2px 4px;
+    }
+    .task-branch > .node-row, .agent-item > .disclosure-branch > .agent-row { cursor: pointer; }
+    .task-branch > .node-row:hover, .agent-item > .disclosure-branch > .agent-row:hover, .drawer-control:hover { background: var(--surface-hover); }
+    .node-row.is-current { min-height: 28px; background: var(--current-row); }
+    .task-branch > .node-row.is-current:hover { background: var(--current-row); }
+    .node-row:focus-visible, .agent-row:focus-visible, .drawer-control:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; }
+
+    .branch-spacer, .branch-chevron { display: grid; width: 14px; height: 14px; place-items: center; }
+    .branch-chevron { color: var(--text-faint); transition: transform 160ms cubic-bezier(.2, 0, 0, 1); }
+    .branch-chevron svg { width: 13px; height: 13px; }
+    .disclosure-branch.is-open > .node-row .branch-chevron, .disclosure-branch.is-open > .agent-row .branch-chevron { transform: rotate(180deg); }
+    .disclosure-region { display: grid; grid-template-rows: 0fr; opacity: 0; visibility: hidden; transition: grid-template-rows 170ms cubic-bezier(.2, 0, 0, 1), opacity 120ms ease, visibility 0s linear 170ms; }
+    .disclosure-clip { min-height: 0; overflow: hidden; }
+    .disclosure-branch.is-open > .disclosure-region { grid-template-rows: 1fr; opacity: 1; visibility: visible; transition-delay: 0s; }
+
+    .node-state-icon { display: grid; width: 14px; height: 14px; color: var(--text-faint); place-items: center; }
+    .node-state-icon svg { width: 14px; height: 14px; }
+    .node-state-icon.live { color: var(--active); }
+    .node-state-icon.closed { color: var(--complete); }
+    .node-state-icon.compacted { color: var(--archive); }
+    .node-state-icon.opened { color: var(--text-soft); }
+    .node-copy, .agent-copy { min-width: 0; }
+    .node-summary, .agent-summary { display: block; white-space: normal; overflow-wrap: anywhere; }
+    .node-summary { color: var(--text); font-size: 10px; font-weight: 550; line-height: 1.35; }
+    .node-row.is-current .node-summary { font-weight: 700; }
+    .current-label { color: var(--active-strong); font-size: 8px; font-weight: 700; white-space: nowrap; }
+
+    .agent-row { min-height: 28px; }
+    .agent-mark { display: grid; color: var(--text-soft); place-items: center; }
+    .agent-mark svg { width: 14px; height: 14px; }
+    .agent-mark.is-running { color: var(--active); }
+    .agent-mark.is-completed { color: var(--complete); }
+    .agent-mark.is-error, .agent-mark.is-not-found { color: var(--error); }
+    .agent-mark.is-interrupted, .agent-mark.is-shutdown { color: var(--warning); }
+    .agent-summary { color: var(--text); font-size: 10px; font-weight: 620; line-height: 1.35; }
+    .agent-state { font-size: 8px; font-weight: 680; white-space: nowrap; color: var(--text-soft); }
+    .agent-state.is-running { color: var(--active-strong); }
+    .agent-state.is-completed { color: var(--complete); }
+    .agent-state.is-error, .agent-state.is-not-found { color: var(--error); }
+    .agent-state.is-interrupted, .agent-state.is-shutdown { color: var(--warning); }
+
+    .drawer-control-item { position: relative; min-height: 16px; padding: 0; list-style: none; }
+    .path-children > .drawer-control-item::before {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -13px;
+      border-left: 1px solid var(--rail);
+      content: "";
+    }
+    .drawer-control {
+      display: grid;
+      width: fit-content;
+      min-height: 16px;
+      grid-template-columns: 14px auto;
+      align-items: center;
+      gap: 6px;
+      margin: 0;
+      padding: 0 6px 0 4px;
+      color: var(--text-soft);
+      cursor: pointer;
+    }
+    .drawer-control svg { width: 13px; height: 13px; }
+    .drawer-control.is-hide .branch-chevron { transform: rotate(180deg); }
+    .drawer-copy { font-size: 8px; font-weight: 620; line-height: 1.35; }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    .path-item.is-drawer-revealed { animation: drawer-reveal 170ms cubic-bezier(.2, 0, 0, 1); }
+    @keyframes drawer-reveal { from { opacity: 0; transform: translateY(-2px); } }
+    .waiting-row { min-height: 30px; padding: 7px 23px; color: var(--text-faint); font-size: 12px; font-style: italic; }
+
+    @container (max-width: 450px) {
+      .path-children { margin-left: 5px; padding-left: 10px; }
+      .path-children > .path-item::before { left: -10px; width: 9px; }
+      .path-children > .path-item:not(:last-child)::after { left: -10px; }
+      .path-children > .drawer-control-item::before { left: -10px; }
+      .node-row, .agent-row { grid-template-columns: 13px 17px minmax(0, 1fr) auto; gap: 5px; }
+      .drawer-control { grid-template-columns: 13px auto; gap: 5px; }
+      .drawer-control .branch-chevron { width: 13px; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .path-item.is-drawer-revealed { animation: none !important; }
+      .branch-chevron, .disclosure-region { transition: none !important; }
+    }
+
+  </style>
+</head>
+<body>
+  <article id="spine-card" class="spine-card">
+    <section class="card-body">
+      <ol id="root-tree" class="path-list"></ol>
+    </section>
+  </article>
+  <script>
+    (() => {
+      "use strict";
+
+      const SVG_NS = "http://www.w3.org/2000/svg";
+      const ICONS = {
+        circle: '<circle cx="12" cy="12" r="10"/>',
+        circleDot: '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="1"/>',
+        circleCheck: '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
+        archive: '<rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8M10 12h4"/>',
+        fork: '<circle cx="12" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><circle cx="18" cy="6" r="3"/><path d="M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9M12 12v3"/>',
+        chevronDown: '<path d="m6 9 6 6 6-6"/>'
+      };
+      const AGENT_LABELS = {
+        pending: "Pending", running: "Running", completed: "Done",
+        interrupted: "Interrupted", error: "Error", shutdown: "Stopped",
+        not_found: "Not found"
+      };
+      const disclosureState = new Map();
+      let payload = null;
+      let lastHeight = 0;
+      let heightFrame = 0;
+      let renderFrame = 0;
+      let disclosureSerial = 0;
+
+      const rootTree = document.querySelector("#root-tree");
+
+      function icon(name, className = "lucide") {
+        const svg = document.createElementNS(SVG_NS, "svg");
+        svg.setAttribute("viewBox", "0 0 24 24");
+        svg.setAttribute("aria-hidden", "true");
+        svg.setAttribute("class", className);
+        svg.innerHTML = ICONS[name];
+        return svg;
+      }
+
+      function element(tag, className, text) {
+        const item = document.createElement(tag);
+        if (className) item.className = className;
+        if (text !== undefined) item.textContent = text;
+        return item;
+      }
+
+      function ordered(items, index) {
+        return [...items].sort((left, right) => {
+          const leftStart = Number.isFinite(left.start) ? left.start : Number.MAX_SAFE_INTEGER;
+          const rightStart = Number.isFinite(right.start) ? right.start : Number.MAX_SAFE_INTEGER;
+          return leftStart - rightStart || index.get(left.nodeId) - index.get(right.nodeId);
+        });
+      }
+
+      function buildContext(treePayload, terminalState = null) {
+        const snapshot = treePayload.snapshot;
+        const spawnCalls = treePayload.spawnCalls || [];
+        const suppressedNodeIds = spawnCalls.flatMap((call) => (call.tasks || []).map((task) => task.resultNodeId).filter(Boolean));
+        const suppressed = new Set(suppressedNodeIds);
+        const terminalNodeStatus = terminalState === "completed" ? "closed" : "opened";
+        const nodes = snapshot.nodes
+          .filter((item) => !suppressed.has(item.nodeId))
+          .map((item) => terminalState && item.status === "live" ? { ...item, status: terminalNodeStatus } : item);
+        const index = new Map(nodes.map((item, position) => [item.nodeId, position]));
+        const byId = new Map(nodes.map((item) => [item.nodeId, item]));
+        const children = new Map();
+        nodes.forEach((item) => {
+          const key = item.parentId || "__root__";
+          if (!children.has(key)) children.set(key, []);
+          children.get(key).push(item);
+        });
+        const activePath = new Set();
+        let cursor = terminalState ? null : byId.get(snapshot.activeNodeId);
+        while (cursor && !activePath.has(cursor.nodeId)) {
+          activePath.add(cursor.nodeId);
+          cursor = cursor.parentId ? byId.get(cursor.parentId) : null;
+        }
+        const roots = [];
+        nodes.filter((item) => item.kind === "root_epoch").forEach((epoch) => {
+          (children.get(epoch.nodeId) || []).filter((item) => item.kind === "task").forEach((item) => roots.push(item));
+        });
+        nodes.filter((item) => item.kind === "task" && (!item.parentId || !byId.has(item.parentId))).forEach((item) => roots.push(item));
+        return { payload: treePayload, snapshot, spawnCalls, index, byId, children, activePath, roots: ordered(roots, index) };
+      }
+
+      function statusIcon(status) {
+        const name = status === "live" ? "circleDot" : status === "closed" ? "circleCheck" : status === "compacted" ? "archive" : "circle";
+        const mark = element("span", `node-state-icon ${status || "opened"}`);
+        const label = status === "live" ? "Current" : status === "closed" ? "Done" : status === "compacted" ? "Compacted" : "Open";
+        mark.append(icon(name), element("span", "sr-only", label));
+        return mark;
+      }
+
+      function spawnOutcomeState(outcome) {
+        if (outcome === "completed") return "completed";
+        if (outcome === "errored") return "error";
+        if (outcome === "aborted") return "shutdown";
+        return null;
+      }
+
+      function validTreePayload(value) {
+        const pending = [{ value, isSubtree: false }];
+        while (pending.length) {
+          const candidate = pending.pop();
+          const current = candidate.value;
+          if (!current || typeof current !== "object" || current.schemaVersion !== 1) return false;
+          if (!Number.isSafeInteger(current.uiRevision) || current.uiRevision < 0) return false;
+          if (candidate.isSubtree && typeof current.threadId !== "string") return false;
+          if (!current.snapshot || typeof current.snapshot !== "object" || !Array.isArray(current.snapshot.nodes)) return false;
+          if (current.snapshot.nodes.some((node) => !node || typeof node !== "object"
+            || typeof node.nodeId !== "string"
+            || (node.summary != null && typeof node.summary !== "string")
+            || (node.spawnOutcome != null && !["completed", "errored", "aborted"].includes(node.spawnOutcome)))) return false;
+          const spawnCalls = current.spawnCalls || [];
+          const agentSubtrees = current.agentSubtrees || [];
+          if (!Array.isArray(spawnCalls) || !Array.isArray(agentSubtrees)) return false;
+          if (spawnCalls.some((call) => !call || typeof call !== "object" || !Array.isArray(call.tasks)
+            || call.tasks.some((task) => !task || typeof task !== "object"
+              || !["pending", "running", "interrupted", "completed", "error", "shutdown", "not_found"].includes(task.status)))) return false;
+          agentSubtrees.forEach((subtree) => pending.push({ value: subtree, isSubtree: true }));
+        }
+        return true;
+      }
+
+      function chevron(className = "branch-chevron") {
+        const mark = element("span", className);
+        mark.append(icon("chevronDown"));
+        return mark;
+      }
+
+      function disclosure(row, createContent, key, defaultOpen) {
+        const branch = element("div", "task-branch disclosure-branch");
+        const region = element("div", "disclosure-region");
+        const clip = element("div", "disclosure-clip");
+        const regionId = `spine-region-${++disclosureSerial}`;
+        const initialOpen = disclosureState.has(key) ? disclosureState.get(key) : defaultOpen;
+        let contentCreated = false;
+        const ensureContent = () => {
+          if (contentCreated) return;
+          clip.append(createContent());
+          contentCreated = true;
+        };
+        region.id = regionId;
+        region.append(clip);
+        row.type = "button";
+        row.setAttribute("aria-controls", regionId);
+        row.setAttribute("aria-expanded", String(initialOpen));
+        branch.classList.toggle("is-open", initialOpen);
+        if (initialOpen) ensureContent();
+        row.addEventListener("click", () => {
+          const open = !branch.classList.contains("is-open");
+          if (open) ensureContent();
+          branch.classList.toggle("is-open", open);
+          row.setAttribute("aria-expanded", String(open));
+          disclosureState.set(key, open);
+          reportHeight();
+        });
+        branch.append(row, region);
+        return branch;
+      }
+
+      function normalizedAgentStatus(raw) {
+        return typeof raw === "string" && raw ? raw : "pending";
+      }
+
+      function agentsFor(parentNodeId, context) {
+        const agents = [];
+        (context.spawnCalls || []).forEach((call) => {
+          if (call.parentNodeId !== parentNodeId) return;
+          [...(call.tasks || [])].sort((a, b) => a.ordinal - b.ordinal).forEach((task) => {
+            agents.push({ ...task, id: `${call.callId}:${task.ordinal}` });
+          });
+        });
+        return agents;
+      }
+
+      function agentSubtreeFor(threadId, treePayload) {
+        return (treePayload.agentSubtrees || []).find((subtree) => subtree.threadId === threadId);
+      }
+
+      function renderAgent(agent, treePayload) {
+        const item = element("li", "path-item agent-item");
+        const state = normalizedAgentStatus(agent.status);
+        const subtree = agentSubtreeFor(agent.threadId, treePayload);
+        const terminalState = ["pending", "running"].includes(state) ? null : state;
+        const subtreeContext = subtree?.snapshot ? buildContext(subtree, terminalState) : null;
+        const hasChildren = Boolean(
+          subtreeContext
+          && (subtreeContext.roots.length || agentsFor(null, subtreeContext).length)
+        );
+        const row = element(hasChildren ? "button" : "div", "agent-row");
+        row.dataset.spineKey = `agent:${agent.threadId}`;
+        if (!hasChildren) row.tabIndex = -1;
+        const mark = element("span", `agent-mark is-${state}`);
+        const copy = element("span", "agent-copy");
+        mark.append(icon("fork"));
+        copy.append(element("span", "agent-summary", agent.summary || "Untitled agent task"));
+        row.append(hasChildren ? chevron() : element("span", "branch-spacer"), mark, copy, element("span", `agent-state is-${state}`, AGENT_LABELS[state] || state));
+        if (!hasChildren) {
+          item.append(row);
+          return item;
+        }
+        item.append(disclosure(row, () => {
+          const children = element("ol", "path-children");
+          appendContextRoots(children, subtreeContext, `agent:${agent.threadId}`);
+          return children;
+        }, `agent:${agent.threadId}`, ["pending", "running"].includes(state)));
+        return item;
+      }
+
+      function renderSpawnResult(item, key) {
+        const state = spawnOutcomeState(item.spawnOutcome);
+        const row = element("div", "agent-row spawn-result-row");
+        row.dataset.spineKey = key;
+        row.tabIndex = -1;
+        const mark = element("span", `agent-mark is-${state}`);
+        const copy = element("span", "agent-copy");
+        mark.append(icon("fork"));
+        copy.append(element("span", "agent-summary", item.summary?.trim() || "Untitled agent task"));
+        row.append(
+          element("span", "branch-spacer"),
+          mark,
+          copy,
+          element("span", `agent-state is-${state}`, AGENT_LABELS[state] || state)
+        );
+        return row;
+      }
+
+      function nodeRow(item, isCurrent, hasChildren, key) {
+        const row = element(
+          hasChildren ? "button" : "div",
+          `node-row${isCurrent ? " is-current" : ""}`
+        );
+        row.dataset.spineKey = key;
+        if (!hasChildren) row.tabIndex = -1;
+        if (isCurrent) row.setAttribute("aria-current", "step");
+        const copy = element("span", "node-copy");
+        copy.append(element("span", "node-summary", item.summary?.trim() || "Untitled task"));
+        row.append(hasChildren ? chevron() : element("span", "branch-spacer"), statusIcon(item.status), copy);
+        if (isCurrent) row.append(element("span", "current-label", "Current"));
+        return row;
+      }
+
+      function drawerControl(count, action, key, onClick) {
+        const noun = count === 1 ? "leaf" : "leaves";
+        const item = element("li", "drawer-control-item");
+        const button = element("button", `drawer-control is-${action}`);
+        button.type = "button";
+        button.dataset.spineKey = key;
+        button.setAttribute("aria-expanded", String(action === "hide"));
+        button.setAttribute("aria-label", `${action === "show" ? "Show" : "Hide"} ${count} previous ${noun}`);
+        button.append(chevron(), element("span", "drawer-copy", `${action === "show" ? "Show" : "Hide"} ${count} previous ${noun}`));
+        button.addEventListener("click", onClick);
+        item.append(button);
+        return { item, button };
+      }
+
+      function appendTaskChildren(list, items, context, scope) {
+        const tasks = ordered(items.filter((item) => item.kind === "task"), context.index);
+        if (tasks.length <= 5) {
+          tasks.forEach((task) => list.append(renderTask(task, context, scope)));
+          return;
+        }
+        const visible = new Set(tasks.slice(-3).map((item) => item.nodeId));
+        tasks.forEach((item) => {
+          if (context.activePath.has(item.nodeId) || item.status === "live") visible.add(item.nodeId);
+        });
+        const hidden = new Set(tasks.filter((item) => !visible.has(item.nodeId)).map((item) => item.nodeId));
+        if (!hidden.size) {
+          tasks.forEach((task) => list.append(renderTask(task, context, scope)));
+          return;
+        }
+        const key = `${scope}:previous`;
+        const entries = tasks.map((task) => ({
+          task,
+          node: hidden.has(task.nodeId) ? null : renderTask(task, context, scope),
+          marker: hidden.has(task.nodeId) ? document.createComment(`spine-task:${task.nodeId}`) : null,
+        }));
+        let open = disclosureState.get(key) || false;
+        let show;
+        let hide;
+        const ensureHiddenRows = () => {
+          entries.forEach((entry) => {
+            if (!entry.marker || entry.node) return;
+            entry.node = renderTask(entry.task, context, scope);
+            entry.marker.replaceWith(entry.node);
+            entry.marker = null;
+          });
+        };
+        const apply = (next, moveFocus = false) => {
+          open = next;
+          disclosureState.set(key, open);
+          if (open) ensureHiddenRows();
+          show.item.hidden = open;
+          hide.item.hidden = !open;
+          entries.forEach(({ task, node }) => {
+            if (!hidden.has(task.nodeId)) return;
+            if (!node) return;
+            node.hidden = !open;
+            node.classList.toggle("is-drawer-revealed", open);
+          });
+          if (moveFocus) {
+            if (open) {
+              const first = entries.find(({ task }) => hidden.has(task.nodeId))?.node.querySelector(".node-row");
+              if (first) { first.tabIndex = -1; first.focus({ preventScroll: true }); }
+            } else {
+              show.button.focus({ preventScroll: true });
+            }
+          }
+          reportHeight();
+        };
+        show = drawerControl(hidden.size, "show", `${key}:show`, () => apply(true, true));
+        hide = drawerControl(hidden.size, "hide", `${key}:hide`, () => apply(false, true));
+        const lastHiddenId = tasks.findLast((task) => hidden.has(task.nodeId))?.nodeId;
+        list.append(show.item);
+        entries.forEach(({ task, node, marker }) => {
+          list.append(node || marker);
+          if (task.nodeId === lastHiddenId) list.append(hide.item);
+        });
+        apply(open);
+      }
+
+      function renderTask(item, context, scope) {
+        const listItem = element("li", "path-item task-item");
+        if (spawnOutcomeState(item.spawnOutcome)) {
+          listItem.classList.add("agent-item", "spawn-result-item");
+          listItem.append(renderSpawnResult(item, `${scope}:spawn-result:${item.nodeId}`));
+          return listItem;
+        }
+        const taskChildren = context.children.get(item.nodeId) || [];
+        const agents = agentsFor(item.nodeId, context);
+        const hasChildren = taskChildren.some((child) => child.kind === "task") || agents.length > 0;
+        const isCurrent = item.nodeId === context.snapshot.activeNodeId && item.status === "live";
+        const row = nodeRow(item, isCurrent, hasChildren, `${scope}:task:${item.nodeId}`);
+        if (!hasChildren) {
+          listItem.append(row);
+          return listItem;
+        }
+        const hasRunningAgent = agents.some((agent) => ["pending", "running"].includes(normalizedAgentStatus(agent.status)));
+        listItem.append(disclosure(row, () => {
+          const children = element("ol", "path-children");
+          appendTaskChildren(children, taskChildren, context, `${scope}:${item.nodeId}`);
+          agents.forEach((agent) => children.append(renderAgent(agent, context.payload)));
+          return children;
+        }, `${scope}:task:${item.nodeId}`, context.activePath.has(item.nodeId) || hasRunningAgent));
+        return listItem;
+      }
+
+      function appendContextRoots(list, context, scope) {
+        appendTaskChildren(list, context.roots, context, scope);
+        agentsFor(null, context).forEach((agent) => list.append(renderAgent(agent, context.payload)));
+      }
+
+      function render() {
+        const focusedKey = document.activeElement?.dataset?.spineKey;
+        disclosureSerial = 0;
+        const context = buildContext(payload);
+        rootTree.replaceChildren();
+        appendContextRoots(rootTree, context, "spine-root");
+        if (!rootTree.children.length) rootTree.append(element("li", "waiting-row", "Waiting for the next task"));
+        if (focusedKey) {
+          [...rootTree.querySelectorAll("[data-spine-key]")]
+            .find((item) => item.dataset.spineKey === focusedKey)
+            ?.focus({ preventScroll: true });
+        }
+        reportHeight();
+      }
+
+      function scheduleRender() {
+        if (renderFrame) return;
+        renderFrame = requestAnimationFrame(() => {
+          renderFrame = 0;
+          render();
+        });
+      }
+
+      function accept(value) {
+        const next = value?.structuredContent || value;
+        if (!validTreePayload(next)) return;
+        if (payload && next.uiRevision <= payload.uiRevision) return;
+        payload = next;
+        scheduleRender();
+      }
+
+      function reportHeight() {
+        if (heightFrame) return;
+        heightFrame = requestAnimationFrame(() => {
+          heightFrame = 0;
+          const card = document.querySelector("#spine-card");
+          const bodyStyle = getComputedStyle(document.body);
+          const verticalPadding = parseFloat(bodyStyle.paddingTop) + parseFloat(bodyStyle.paddingBottom);
+          const height = Math.ceil(card.getBoundingClientRect().height + verticalPadding);
+          if (!height || height === lastHeight) return;
+          lastHeight = height;
+          try { Promise.resolve(window.openai?.notifyIntrinsicHeight?.(height)).catch(() => {}); } catch (_) {}
+        });
+      }
+
+      function notifyTransparentBackground() {
+        try { Promise.resolve(window.openai?.notifyBackgroundColor?.("transparent")).catch(() => {}); } catch (_) {}
+      }
+
+      function applyGlobals(globals) { accept(globals?.toolOutput); }
+      applyGlobals(window.openai || {});
+      notifyTransparentBackground();
+      window.addEventListener("openai:set_globals", (event) => {
+        applyGlobals(event.detail?.globals || {});
+        notifyTransparentBackground();
+      });
+      window.addEventListener("message", (event) => {
+        if (event.data?.method === "ui/notifications/tool-result") accept(event.data.params?.structuredContent);
+      });
+      if ("ResizeObserver" in window) new ResizeObserver(reportHeight).observe(document.querySelector("#spine-card"));
+      reportHeight();
+    })();
+  </script>
+</body>
+</html>

--- a/codex-rs/app-server/src/spine_ui_tests.rs
+++ b/codex-rs/app-server/src/spine_ui_tests.rs
@@ -1,0 +1,447 @@
+use super::*;
+use codex_app_server_protocol::McpToolCallStatus;
+use codex_app_server_protocol::ThreadItem;
+use codex_protocol::AgentPath;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::AgentStatus;
+use codex_protocol::protocol::SpineSpawnOutcome;
+use codex_protocol::protocol::SpineTreeNodeKind;
+use codex_protocol::protocol::SpineTreeNodeSnapshot;
+use codex_protocol::protocol::SpineTreeNodeStatus;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+fn snapshot(sequence: u64, active_node_id: &str) -> SpineTreeUpdateEvent {
+    SpineTreeUpdateEvent {
+        snapshot_seq: sequence,
+        active_node_id: active_node_id.to_string(),
+        settled_spawn_call_ids: Vec::new(),
+        nodes: vec![
+            node(
+                "1",
+                None,
+                SpineTreeNodeKind::RootEpoch,
+                SpineTreeNodeStatus::Opened,
+                None,
+            ),
+            node(
+                "1.1",
+                Some("1"),
+                SpineTreeNodeKind::Task,
+                if active_node_id == "1.1" {
+                    SpineTreeNodeStatus::Live
+                } else {
+                    SpineTreeNodeStatus::Closed
+                },
+                Some("Render the Spine tree"),
+            ),
+            node(
+                "1.2",
+                Some("1"),
+                SpineTreeNodeKind::Task,
+                if active_node_id == "1.2" {
+                    SpineTreeNodeStatus::Live
+                } else {
+                    SpineTreeNodeStatus::Opened
+                },
+                Some("Verify the result"),
+            ),
+        ],
+    }
+}
+
+fn node(
+    node_id: &str,
+    parent_id: Option<&str>,
+    kind: SpineTreeNodeKind,
+    status: SpineTreeNodeStatus,
+    summary: Option<&str>,
+) -> SpineTreeNodeSnapshot {
+    SpineTreeNodeSnapshot {
+        node_id: node_id.to_string(),
+        parent_id: parent_id.map(str::to_string),
+        kind,
+        status,
+        summary: summary.map(str::to_string),
+        memory_summary: Some("not sent to the renderer".to_string()),
+        spawn_outcome: None,
+        start: 0,
+        end: Some(10),
+        context_pressure: None,
+    }
+}
+
+fn spawn_progress(call_id: &str, status: AgentStatus) -> SpineSpawnProgressEvent {
+    spawn_progress_for_thread(call_id, ThreadId::new(), status)
+}
+
+fn spawn_progress_for_thread(
+    call_id: &str,
+    thread_id: ThreadId,
+    status: AgentStatus,
+) -> SpineSpawnProgressEvent {
+    SpineSpawnProgressEvent {
+        call_id: call_id.to_string(),
+        tasks: vec![SpineSpawnTaskProgress {
+            ordinal: 0,
+            summary: format!("Run {call_id}"),
+            thread_id,
+            agent_path: Some(
+                AgentPath::try_from(format!("/root/{call_id}")).expect("valid agent path"),
+            ),
+            status,
+        }],
+    }
+}
+
+#[test]
+fn only_tree_affecting_spine_calls_activate_the_ui() {
+    for tool in ["open", "next", "close", "spawn"] {
+        assert!(is_tree_tool_call(&function_call(tool, Some("spine"))));
+        assert!(is_tree_tool_call(&function_call(
+            &format!("spine.{tool}"),
+            None
+        )));
+    }
+    assert!(!is_tree_tool_call(&function_call("trim", Some("spine"))));
+    assert!(!is_tree_tool_call(&function_call("open", Some("other"))));
+    assert!(!is_tree_tool_call(&function_call("shell", None)));
+}
+
+fn function_call(name: &str, namespace: Option<&str>) -> ResponseItem {
+    ResponseItem::FunctionCall {
+        id: None,
+        name: name.to_string(),
+        namespace: namespace.map(str::to_string),
+        arguments: "{}".to_string(),
+        call_id: format!("call-{name}"),
+        internal_chat_message_metadata_passthrough: None,
+    }
+}
+
+#[test]
+fn resource_is_scoped_and_self_contained() {
+    let response = read_resource(SERVER_NAME, RESOURCE_URI).expect("Spine UI resource");
+    assert_eq!(response.contents.len(), 1);
+    assert!(read_resource("other", RESOURCE_URI).is_none());
+    assert!(read_resource(SERVER_NAME, "ui://spine/other.html").is_none());
+    assert!(RESOURCE_HTML.contains("default-src 'none'"));
+    assert!(RESOURCE_HTML.contains("ResizeObserver"));
+    assert!(RESOURCE_HTML.contains("function validTreePayload(value)"));
+    assert!(RESOURCE_HTML.contains("spawnCalls.flatMap"));
+    assert!(!RESOURCE_HTML.contains("<script src="));
+    assert!(!RESOURCE_HTML.contains("<link rel=\"stylesheet\""));
+    assert!(!RESOURCE_HTML.contains("https://"));
+
+    let status = server_status(true);
+    let tool = status.tools.get("spine_tree").expect("Spine Tree tool");
+    assert_eq!(tool.title.as_deref(), Some("Spine Tree"));
+    assert_eq!(status.name, SERVER_NAME);
+    assert_eq!(status.resources[0].uri, RESOURCE_URI);
+    assert_eq!(
+        tool.meta.as_ref().expect("tool metadata")["ui"]["resourceUri"],
+        RESOURCE_URI
+    );
+}
+
+#[test]
+fn render_payload_contains_only_fields_used_by_the_card() {
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(5, "1.1"));
+    state.record_spawn_progress(spawn_progress("child", AgentStatus::Running));
+
+    let response = tool_call_response("thread-1", Some(&state));
+    let content = response.structured_content.expect("structured content");
+
+    assert_eq!(response.is_error, Some(false));
+    assert_eq!(content["schemaVersion"], 1);
+    assert_eq!(content["snapshot"]["activeNodeId"], "1.1");
+    assert!(content["snapshot"].get("snapshotSeq").is_none());
+    assert!(
+        content["snapshot"]["nodes"][0]
+            .get("memorySummary")
+            .is_none()
+    );
+    assert!(content["snapshot"]["nodes"][0].get("end").is_none());
+    assert!(
+        content["snapshot"]["nodes"][0]
+            .get("contextPressure")
+            .is_none()
+    );
+    assert!(
+        content["spawnCalls"][0]["tasks"][0]
+            .get("agentPath")
+            .is_none()
+    );
+    assert!(content.get("agentGenerations").is_none());
+    assert!(content.get("invalidatedAgentGenerations").is_none());
+    assert!(content.get("agentSyncTimeoutGenerations").is_none());
+    assert!(content.get("suppressedNodeIds").is_none());
+}
+
+#[test]
+fn spawn_calls_keep_creation_order_and_original_parent() {
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress("first", AgentStatus::Running));
+    state.record_snapshot(snapshot(2, "1.2"));
+    state.record_spawn_progress(spawn_progress("second", AgentStatus::Running));
+    state.record_spawn_progress(spawn_progress("first", AgentStatus::Completed(None)));
+
+    let content = state.structured_content().expect("structured content");
+    assert_eq!(content["spawnCalls"][0]["callId"], "first");
+    assert_eq!(content["spawnCalls"][0]["parentNodeId"], "1.1");
+    assert_eq!(
+        content["spawnCalls"][0]["tasks"][0]["status"],
+        json!("completed")
+    );
+    assert_eq!(content["spawnCalls"][1]["callId"], "second");
+    assert_eq!(content["spawnCalls"][1]["parentNodeId"], "1.2");
+}
+
+#[test]
+fn changed_snapshot_at_the_same_boundary_advances_the_ui_revision() {
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(7, "1.1"));
+    let first_revision = state.revision;
+
+    state.record_snapshot(snapshot(7, "1.2"));
+    assert!(state.revision > first_revision);
+    let second_revision = state.revision;
+    state.record_snapshot(snapshot(7, "1.2"));
+    assert_eq!(state.revision, second_revision);
+}
+
+#[test]
+fn replacement_generation_cannot_be_removed_by_an_older_terminal() {
+    let child_thread_id = ThreadId::new();
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress_for_thread(
+        "child",
+        child_thread_id,
+        AgentStatus::Running,
+    ));
+
+    let mut first = SpineUiState::default();
+    first.record_snapshot(snapshot(8, "1.2"));
+    assert!(state.record_agent_state(child_thread_id, 1, first));
+    let mut replacement = SpineUiState::default();
+    replacement.record_snapshot(snapshot(1, "1.1"));
+    assert!(state.record_agent_state(child_thread_id, 2, replacement));
+    assert!(!state.remove_agent_state(child_thread_id, 1));
+    assert!(state.remove_agent_state(child_thread_id, 2));
+}
+
+#[test]
+fn agent_sync_timeout_is_visible_until_the_matching_terminal_state_arrives() {
+    let child_thread_id = ThreadId::new();
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress_for_thread(
+        "child",
+        child_thread_id,
+        AgentStatus::Running,
+    ));
+
+    assert!(state.mark_agent_sync_timeout(child_thread_id, 7));
+    assert_eq!(
+        state.structured_content().expect("timed out content")["spawnCalls"][0]["tasks"][0]["status"],
+        json!("error")
+    );
+    assert!(!state.clear_agent_sync_timeout(child_thread_id, 6));
+    assert!(state.clear_agent_sync_timeout(child_thread_id, 7));
+}
+
+#[test]
+fn render_payload_omits_agent_terminal_messages() {
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress(
+        "failed",
+        AgentStatus::Errored("sensitive diagnostic".to_string()),
+    ));
+    state.record_spawn_progress(spawn_progress(
+        "completed",
+        AgentStatus::Completed(Some("sensitive final answer".to_string())),
+    ));
+
+    let content = state.structured_content().expect("structured content");
+    assert_eq!(content["spawnCalls"][0]["tasks"][0]["status"], "error");
+    assert_eq!(content["spawnCalls"][1]["tasks"][0]["status"], "completed");
+    let serialized = content.to_string();
+    assert!(!serialized.contains("sensitive diagnostic"));
+    assert!(!serialized.contains("sensitive final answer"));
+}
+
+#[test]
+fn settled_spawn_call_links_its_result_node_without_duplicate_payload_metadata() {
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress("settled", AgentStatus::Running));
+
+    let mut committed = snapshot(2, "1.1");
+    committed.settled_spawn_call_ids = vec!["settled".to_string()];
+    let mut result_node = node(
+        "1.1.1",
+        Some("1.1"),
+        SpineTreeNodeKind::Task,
+        SpineTreeNodeStatus::Closed,
+        Some("Run settled"),
+    );
+    result_node.spawn_outcome = Some(SpineSpawnOutcome::Completed);
+    committed.nodes.push(result_node);
+    state.record_snapshot(committed);
+
+    let content = state.structured_content().expect("structured content");
+    assert_eq!(
+        content["spawnCalls"][0]["tasks"][0]["resultNodeId"],
+        "1.1.1"
+    );
+    assert_eq!(content["snapshot"]["nodes"][3]["nodeId"], "1.1.1");
+    assert!(content.get("suppressedNodeIds").is_none());
+}
+
+#[test]
+fn agent_subtree_is_nested_under_its_matching_agent() {
+    let child_thread_id = ThreadId::new();
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress_for_thread(
+        "child",
+        child_thread_id,
+        AgentStatus::Running,
+    ));
+    let mut child_state = SpineUiState::default();
+    child_state.record_snapshot(snapshot(4, "1.2"));
+    state.record_agent_state(child_thread_id, 1, child_state);
+
+    let content = state.structured_content().expect("structured content");
+    assert_eq!(
+        content["agentSubtrees"][0]["threadId"],
+        child_thread_id.to_string()
+    );
+    assert_eq!(
+        content["agentSubtrees"][0]["snapshot"]["activeNodeId"],
+        "1.2"
+    );
+}
+
+#[test]
+fn agent_with_a_parent_outside_the_current_snapshot_is_rendered_at_the_root() {
+    let child_thread_id = ThreadId::new();
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(1, "1.1"));
+    state.record_spawn_progress(spawn_progress_for_thread(
+        "child",
+        child_thread_id,
+        AgentStatus::Running,
+    ));
+
+    let mut child_state = SpineUiState::default();
+    child_state.record_snapshot(snapshot(1, "1.2"));
+    state.record_agent_state(child_thread_id, 1, child_state);
+
+    let snapshot_without_parent = SpineTreeUpdateEvent {
+        snapshot_seq: 2,
+        active_node_id: "2.1".to_string(),
+        settled_spawn_call_ids: Vec::new(),
+        nodes: vec![node(
+            "2.1",
+            None,
+            SpineTreeNodeKind::Task,
+            SpineTreeNodeStatus::Live,
+            Some("Current turn"),
+        )],
+    };
+    state.record_snapshot(snapshot_without_parent);
+
+    let content = state.structured_content().expect("structured content");
+    assert_eq!(content["spawnCalls"][0]["callId"], "child");
+    assert!(content["spawnCalls"][0].get("parentNodeId").is_none());
+    assert_eq!(
+        content["agentSubtrees"][0]["threadId"],
+        child_thread_id.to_string()
+    );
+}
+
+#[test]
+fn parent_filter_removes_inherited_nodes_and_reanchors_nested_agents() {
+    let grandchild_thread_id = ThreadId::new();
+    let mut child_state = SpineUiState::default();
+    child_state.record_snapshot(snapshot(4, "1.2"));
+    child_state.record_spawn_progress(spawn_progress_for_thread(
+        "nested",
+        grandchild_thread_id,
+        AgentStatus::Running,
+    ));
+    let baseline_node_ids = child_state
+        .latest_snapshot()
+        .expect("child snapshot")
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .collect();
+
+    let filtered = child_state.filtered_for_parent(&baseline_node_ids);
+    let content = filtered.structured_content().expect("filtered content");
+
+    assert_eq!(content["snapshot"]["nodes"], json!([]));
+    assert!(content["spawnCalls"][0].get("parentNodeId").is_none());
+    assert_eq!(
+        content["spawnCalls"][0]["tasks"][0]["threadId"],
+        grandchild_thread_id.to_string()
+    );
+}
+
+#[test]
+fn live_item_uses_one_stable_id_per_turn() {
+    let mut state = SpineUiState::default();
+    state.record_snapshot(snapshot(7, "1.1"));
+    let started =
+        snapshot_started_notification("thread-1", "turn-1", &state).expect("started notification");
+    state.record_snapshot(snapshot(8, "1.2"));
+    let started_refresh = snapshot_started_notification("thread-1", "turn-1", &state)
+        .expect("started refresh notification");
+    state.mark_completed();
+    let completed = snapshot_completed_notification("thread-1", "turn-1", &state)
+        .expect("completed notification");
+    let completed_refresh = snapshot_completed_notification("thread-1", "turn-1", &state)
+        .expect("completed refresh notification");
+    let other_turn = snapshot_completed_notification("thread-1", "turn-2", &state)
+        .expect("second completed notification");
+
+    let ThreadItem::McpToolCall {
+        id: started_id,
+        status: started_status,
+        result: Some(started_result),
+        ..
+    } = started.item
+    else {
+        panic!("expected MCP tool call item");
+    };
+    let ThreadItem::McpToolCall {
+        id: completed_id,
+        status: completed_status,
+        result: Some(completed_result),
+        ..
+    } = completed.item
+    else {
+        panic!("expected MCP tool call item");
+    };
+    let ThreadItem::McpToolCall {
+        result: Some(other_result),
+        ..
+    } = other_turn.item
+    else {
+        panic!("expected second MCP tool call result");
+    };
+
+    assert_eq!(started_id, completed_id);
+    assert_eq!(started.started_at_ms, started_refresh.started_at_ms);
+    assert_eq!(completed.completed_at_ms, completed_refresh.completed_at_ms);
+    assert_eq!(started_status, McpToolCallStatus::InProgress);
+    assert_eq!(completed_status, McpToolCallStatus::Completed);
+    assert_eq!(started_result.meta, completed_result.meta);
+    assert_ne!(started_result.meta, other_result.meta);
+}

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -1,5 +1,6 @@
 use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::ConnectionRequestId;
+use crate::spine_ui::SpineUiState;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadGoal;
 use codex_app_server_protocol::ThreadHistoryBuilder;
@@ -14,6 +15,8 @@ use codex_protocol::ThreadId;
 use codex_protocol::config_types::MultiAgentMode;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::SpineSpawnProgressEvent;
+use codex_protocol::protocol::SpineTreeUpdateEvent;
 use codex_rollout::state_db::StateDbHandle;
 use codex_utils_path_uri::LegacyAppPathString;
 use std::collections::HashMap;
@@ -26,6 +29,14 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tracing::error;
+
+#[path = "thread_state_spine_ui.rs"]
+mod spine_ui_runtime;
+
+use spine_ui_runtime::SpineUiParentRoute;
+use spine_ui_runtime::SpineUiRouteTerminalState;
+use spine_ui_runtime::SpineUiTerminalAck;
+use spine_ui_runtime::SpineUiThreadRuntime;
 
 type PendingInterruptQueue = Vec<ConnectionRequestId>;
 
@@ -64,6 +75,17 @@ pub(crate) enum ThreadListenerCommand {
         request_id: RequestId,
         completion_tx: oneshot::Sender<()>,
     },
+    ForwardSpineUiAgentState {
+        child_thread_id: ThreadId,
+        parent_turn_id: String,
+        generation: u64,
+        state: Option<SpineUiState>,
+        terminal: bool,
+    },
+    EmitSpineUiInvalidation {
+        turn_id: String,
+        state: SpineUiState,
+    },
 }
 
 /// Per-conversation accumulation of the latest states e.g. error message while a turn runs.
@@ -72,6 +94,14 @@ pub(crate) struct TurnSummary {
     pub(crate) started_at: Option<i64>,
     pub(crate) command_execution_started: HashSet<String>,
     pub(crate) last_error: Option<TurnError>,
+    pub(crate) spine_ui: SpineUiState,
+    spine_ui_turn_id: Option<String>,
+}
+
+impl TurnSummary {
+    pub(crate) fn active_spine_ui(&self, turn_id: &str) -> Option<&SpineUiState> {
+        (self.spine_ui_turn_id.as_deref() == Some(turn_id)).then_some(&self.spine_ui)
+    }
 }
 
 #[derive(Default)]
@@ -79,6 +109,7 @@ pub(crate) struct ThreadState {
     pub(crate) pending_interrupts: PendingInterruptQueue,
     pub(crate) pending_rollbacks: Option<ConnectionRequestId>,
     pub(crate) turn_summary: TurnSummary,
+    spine_ui_runtime: SpineUiThreadRuntime,
     pub(crate) last_terminal_turn_id: Option<String>,
     pub(crate) cancel_tx: Option<oneshot::Sender<()>>,
     pub(crate) experimental_raw_events: bool,
@@ -105,9 +136,7 @@ impl ThreadState {
         watch_registration: WatchRegistration,
         thread_settings_baseline: ThreadSettings,
     ) -> (mpsc::UnboundedReceiver<ThreadListenerCommand>, u64) {
-        if let Some(previous) = self.cancel_tx.replace(cancel_tx) {
-            let _ = previous.send(());
-        }
+        self.replace_listener_cancel_tx(cancel_tx);
         self.listener_generation = self.listener_generation.wrapping_add(1);
         self.last_thread_settings = Some(thread_settings_baseline);
         let (listener_command_tx, listener_command_rx) = mpsc::unbounded_channel();
@@ -115,6 +144,13 @@ impl ThreadState {
         self.listener_thread = Some(Arc::downgrade(conversation));
         self.watch_registration = watch_registration;
         (listener_command_rx, self.listener_generation)
+    }
+
+    fn replace_listener_cancel_tx(&mut self, cancel_tx: oneshot::Sender<()>) {
+        if let Some(previous) = self.cancel_tx.replace(cancel_tx) {
+            let _ = previous.send(());
+            self.clear_spine_ui_transient_state();
+        }
     }
 
     pub(crate) fn clear_listener(&mut self) {
@@ -125,6 +161,7 @@ impl ThreadState {
         self.current_turn_history.reset();
         self.listener_thread = None;
         self.watch_registration = WatchRegistration::default();
+        self.clear_spine_ui_transient_state();
     }
 
     pub(crate) fn set_experimental_raw_events(&mut self, enabled: bool) {
@@ -144,8 +181,16 @@ impl ThreadState {
     pub(crate) fn track_current_turn_event(&mut self, event_turn_id: &str, event: &EventMsg) {
         if let EventMsg::TurnStarted(payload) = event {
             self.turn_summary.started_at = payload.started_at;
+            self.start_spine_ui_turn();
+            self.last_terminal_turn_id = None;
         }
         self.current_turn_history.handle_event(event);
+        if self.has_active_turn(event_turn_id)
+            && let EventMsg::RawResponseItem(payload) = event
+            && crate::spine_ui::is_tree_tool_call(&payload.item)
+        {
+            self.activate_spine_ui(event_turn_id);
+        }
         if matches!(event, EventMsg::TurnAborted(_) | EventMsg::TurnComplete(_))
             && !self.current_turn_history.has_active_turn()
         {
@@ -253,6 +298,8 @@ struct ThreadEntry {
     state: Arc<Mutex<ThreadState>>,
     connection_ids: HashSet<ConnectionId>,
     has_connections_watcher: watch::Sender<bool>,
+    listener_generation: u64,
+    spine_ui_terminal_ack: Option<SpineUiTerminalAck>,
 }
 
 impl Default for ThreadEntry {
@@ -261,6 +308,8 @@ impl Default for ThreadEntry {
             state: Arc::new(Mutex::new(ThreadState::default())),
             connection_ids: HashSet::new(),
             has_connections_watcher: watch::channel(false).0,
+            listener_generation: 0,
+            spine_ui_terminal_ack: None,
         }
     }
 }
@@ -280,6 +329,8 @@ struct ThreadStateManagerInner {
     live_connections: HashMap<ConnectionId, ConnectionCapabilities>,
     threads: HashMap<ThreadId, ThreadEntry>,
     thread_ids_by_connection: HashMap<ConnectionId, HashSet<ThreadId>>,
+    spine_ui_parent_by_child: HashMap<ThreadId, SpineUiParentRoute>,
+    next_spine_ui_route_generation: u64,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -404,6 +455,18 @@ impl ThreadStateManager {
                 thread_ids.remove(&thread_id);
                 !thread_ids.is_empty()
             });
+            state
+                .spine_ui_parent_by_child
+                .retain(|child_thread_id, route| {
+                    let remove =
+                        *child_thread_id == thread_id || route.parent_thread_id == thread_id;
+                    if remove {
+                        route
+                            .terminal_tx
+                            .send_replace(SpineUiRouteTerminalState::Invalidated);
+                    }
+                    !remove
+                });
             thread_state
         };
         self.unregister_listener_command_tx(thread_id);
@@ -423,7 +486,13 @@ impl ThreadStateManager {
 
     pub(crate) async fn clear_all_listeners(&self) {
         let thread_states = {
-            let state = self.state.lock().await;
+            let mut state = self.state.lock().await;
+            for route in state.spine_ui_parent_by_child.values() {
+                route
+                    .terminal_tx
+                    .send_replace(SpineUiRouteTerminalState::Invalidated);
+            }
+            state.spine_ui_parent_by_child.clear();
             state
                 .threads
                 .iter()
@@ -450,7 +519,7 @@ impl ThreadStateManager {
         thread_id: ThreadId,
         connection_id: ConnectionId,
     ) -> bool {
-        {
+        let thread_state = {
             let mut state = self.state.lock().await;
             if !state.threads.contains_key(&thread_id) {
                 return false;
@@ -473,8 +542,15 @@ impl ThreadStateManager {
             if let Some(thread_entry) = state.threads.get_mut(&thread_id) {
                 thread_entry.connection_ids.remove(&connection_id);
                 thread_entry.update_has_connections();
+                thread_entry.state.clone()
+            } else {
+                return false;
             }
         };
+        thread_state
+            .lock()
+            .await
+            .remove_spine_ui_terminal_connection_id(connection_id);
 
         true
     }

--- a/codex-rs/app-server/src/thread_state_spine_ui.rs
+++ b/codex-rs/app-server/src/thread_state_spine_ui.rs
@@ -1,0 +1,314 @@
+use super::*;
+use codex_app_server_protocol::TurnStatus;
+
+#[derive(Default)]
+pub(super) struct SpineUiThreadRuntime {
+    cumulative: SpineUiState,
+    terminal: Option<SpineUiTerminal>,
+    next_revision: u64,
+}
+
+struct SpineUiTerminal {
+    turn_id: String,
+    state: SpineUiState,
+    connection_ids: Vec<ConnectionId>,
+}
+
+impl SpineUiThreadRuntime {
+    pub(super) fn clear_terminal(&mut self) {
+        self.terminal = None;
+    }
+
+    pub(super) fn clear_transient_state(&mut self) {
+        self.cumulative = SpineUiState::default();
+        self.terminal = None;
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct SpineUiTerminalAck {
+    pub(super) listener_generation: u64,
+    pub(super) state: Option<SpineUiState>,
+}
+
+#[derive(Clone)]
+pub(super) struct SpineUiParentRoute {
+    pub(super) parent_thread_id: ThreadId,
+    pub(super) parent_turn_id: String,
+    baseline_node_ids: Arc<HashSet<String>>,
+    generation: u64,
+    timed_out: bool,
+    queued_revision: Option<u64>,
+    last_forwarded_revision: Option<u64>,
+    pub(super) terminal_tx: watch::Sender<SpineUiRouteTerminalState>,
+}
+
+impl SpineUiParentRoute {
+    fn has_nested_sync_timeout(&self) -> bool {
+        match &*self.terminal_tx.borrow() {
+            SpineUiRouteTerminalState::Settled(Some(state)) => state.has_agent_sync_timeout(),
+            SpineUiRouteTerminalState::Pending
+            | SpineUiRouteTerminalState::TimedOut
+            | SpineUiRouteTerminalState::Settled(None)
+            | SpineUiRouteTerminalState::Invalidated => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) enum SpineUiRouteTerminalState {
+    #[default]
+    Pending,
+    TimedOut,
+    Settled(Option<Box<SpineUiState>>),
+    Invalidated,
+}
+
+pub(crate) struct SpineUiAgentRefresh {
+    pub(crate) state: SpineUiState,
+    pub(crate) connection_ids: Vec<ConnectionId>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SpineUiAgentForwardKind {
+    Live,
+    TerminalRefresh,
+}
+
+impl ThreadState {
+    pub(crate) fn has_active_turn(&self, turn_id: &str) -> bool {
+        self.current_turn_history
+            .active_turn_snapshot()
+            .is_some_and(|turn| turn.id == turn_id && turn.status == TurnStatus::InProgress)
+    }
+
+    pub(crate) fn live_spine_ui(&self, turn_id: &str) -> Option<&SpineUiState> {
+        self.has_active_turn(turn_id)
+            .then(|| self.turn_summary.active_spine_ui(turn_id))
+            .flatten()
+    }
+
+    fn current_spine_ui_for_forward(&self) -> Option<&SpineUiState> {
+        self.current_turn_history
+            .active_turn_snapshot()
+            .and_then(|turn| self.turn_summary.active_spine_ui(&turn.id))
+            .filter(|state| state.latest_snapshot().is_some())
+            .or_else(|| {
+                self.spine_ui_runtime
+                    .terminal
+                    .as_ref()
+                    .map(|terminal| &terminal.state)
+            })
+    }
+
+    pub(crate) fn active_spine_ui_snapshot(&self) -> Option<(String, SpineUiState)> {
+        let turn = self.current_turn_history.active_turn_snapshot()?;
+        self.turn_summary
+            .active_spine_ui(&turn.id)
+            .filter(|state| state.latest_snapshot().is_some())
+            .cloned()
+            .map(|state| (turn.id, state))
+    }
+
+    pub(crate) fn record_spine_ui_snapshot(&mut self, snapshot: SpineTreeUpdateEvent) -> bool {
+        if self.turn_summary.spine_ui_turn_id.is_none()
+            || !self.current_turn_history.has_active_turn()
+        {
+            self.spine_ui_runtime.cumulative.record_snapshot(snapshot);
+            return false;
+        }
+        let changed = self.turn_summary.spine_ui.record_snapshot(snapshot);
+        if changed {
+            self.assign_turn_summary_spine_ui_revision();
+        }
+        changed
+    }
+
+    pub(crate) fn record_spine_ui_spawn_progress(
+        &mut self,
+        progress: SpineSpawnProgressEvent,
+    ) -> bool {
+        if self.turn_summary.spine_ui_turn_id.is_none()
+            || !self.current_turn_history.has_active_turn()
+        {
+            return false;
+        }
+        let changed = self.turn_summary.spine_ui.record_spawn_progress(progress);
+        if changed {
+            self.assign_turn_summary_spine_ui_revision();
+        }
+        changed
+    }
+
+    pub(crate) fn record_spine_ui_agent_state(
+        &mut self,
+        child_thread_id: ThreadId,
+        generation: u64,
+        child_state: SpineUiState,
+    ) -> bool {
+        let changed =
+            self.turn_summary
+                .spine_ui
+                .record_agent_state(child_thread_id, generation, child_state);
+        if changed {
+            self.assign_turn_summary_spine_ui_revision();
+        }
+        changed
+    }
+
+    pub(crate) fn mark_spine_ui_agent_sync_timeout(
+        &mut self,
+        child_thread_id: ThreadId,
+        generation: u64,
+    ) -> bool {
+        let changed = self
+            .turn_summary
+            .spine_ui
+            .mark_agent_sync_timeout(child_thread_id, generation);
+        if changed {
+            self.assign_turn_summary_spine_ui_revision();
+        }
+        changed
+    }
+
+    pub(crate) fn record_completed_spine_ui_agent_terminal(
+        &mut self,
+        parent_turn_id: &str,
+        child_thread_id: ThreadId,
+        generation: u64,
+        child_state: Option<SpineUiState>,
+    ) -> Option<SpineUiAgentRefresh> {
+        let mut terminal = self.spine_ui_runtime.terminal.take()?;
+        if terminal.turn_id != parent_turn_id {
+            self.spine_ui_runtime.terminal = Some(terminal);
+            return None;
+        }
+
+        let changed = match child_state {
+            Some(child_state) => {
+                let state_changed =
+                    terminal
+                        .state
+                        .record_agent_state(child_thread_id, generation, child_state);
+                let timeout_cleared = terminal
+                    .state
+                    .clear_agent_sync_timeout(child_thread_id, generation);
+                state_changed || timeout_cleared
+            }
+            None => terminal
+                .state
+                .remove_agent_state(child_thread_id, generation),
+        };
+        if !changed {
+            self.spine_ui_runtime.terminal = Some(terminal);
+            return None;
+        }
+
+        let revision = self.allocate_spine_ui_revision(terminal.state.revision());
+        terminal.state.set_revision(revision);
+        self.spine_ui_runtime.cumulative = terminal.state.clone();
+        let refresh = SpineUiAgentRefresh {
+            state: terminal.state.clone(),
+            connection_ids: terminal.connection_ids.clone(),
+        };
+        self.spine_ui_runtime.terminal = Some(terminal);
+        Some(refresh)
+    }
+
+    pub(crate) fn set_spine_ui_terminal_connection_ids(
+        &mut self,
+        turn_id: &str,
+        connection_ids: &[ConnectionId],
+    ) {
+        if let Some(terminal) = self.spine_ui_runtime.terminal.as_mut()
+            && terminal.turn_id == turn_id
+        {
+            terminal.connection_ids = connection_ids.to_vec();
+        }
+    }
+
+    pub(crate) fn remove_spine_ui_terminal_connection_id(&mut self, connection_id: ConnectionId) {
+        if let Some(terminal) = self.spine_ui_runtime.terminal.as_mut() {
+            terminal
+                .connection_ids
+                .retain(|candidate| *candidate != connection_id);
+        }
+    }
+
+    pub(crate) fn invalidate_spine_ui_agent_state(
+        &mut self,
+        child_thread_id: ThreadId,
+        generation: u64,
+    ) -> bool {
+        let changed = self
+            .turn_summary
+            .spine_ui
+            .remove_agent_state(child_thread_id, generation);
+        if changed {
+            self.assign_turn_summary_spine_ui_revision();
+        }
+        changed
+    }
+
+    fn assign_turn_summary_spine_ui_revision(&mut self) {
+        let revision = self.allocate_spine_ui_revision(self.turn_summary.spine_ui.revision());
+        self.turn_summary.spine_ui.set_revision(revision);
+    }
+
+    fn allocate_spine_ui_revision(&mut self, candidate: u64) -> u64 {
+        let revision = self
+            .spine_ui_runtime
+            .next_revision
+            .saturating_add(1)
+            .max(candidate);
+        self.spine_ui_runtime.next_revision = revision;
+        revision
+    }
+
+    pub(crate) fn reset_spine_ui_after_rollback(&mut self) {
+        self.clear_spine_ui_transient_state();
+        self.last_terminal_turn_id = None;
+    }
+
+    pub(super) fn clear_spine_ui_transient_state(&mut self) {
+        self.turn_summary.spine_ui = SpineUiState::default();
+        self.turn_summary.spine_ui_turn_id = None;
+        self.spine_ui_runtime.clear_transient_state();
+    }
+
+    pub(crate) fn take_turn_summary(&mut self) -> TurnSummary {
+        let mut turn_summary = std::mem::take(&mut self.turn_summary);
+        if let Some(turn_id) = turn_summary.spine_ui_turn_id.as_ref()
+            && turn_summary.spine_ui.latest_snapshot().is_some()
+        {
+            turn_summary.spine_ui.mark_completed();
+            self.spine_ui_runtime.cumulative = turn_summary.spine_ui.clone();
+            self.spine_ui_runtime.terminal = Some(SpineUiTerminal {
+                turn_id: turn_id.clone(),
+                state: turn_summary.spine_ui.clone(),
+                connection_ids: Vec::new(),
+            });
+        }
+        turn_summary
+    }
+
+    pub(super) fn start_spine_ui_turn(&mut self) {
+        self.spine_ui_runtime.clear_terminal();
+        self.turn_summary.spine_ui = SpineUiState::default();
+        self.turn_summary.spine_ui_turn_id = None;
+    }
+
+    pub(super) fn activate_spine_ui(&mut self, turn_id: &str) {
+        if self.turn_summary.spine_ui_turn_id.as_deref() != Some(turn_id) {
+            self.turn_summary.spine_ui = self.spine_ui_runtime.cumulative.carry_forward();
+            self.turn_summary.spine_ui_turn_id = Some(turn_id.to_string());
+        }
+    }
+}
+
+#[path = "thread_state_spine_ui_manager.rs"]
+mod manager;
+
+#[cfg(test)]
+#[path = "thread_state_spine_ui_tests.rs"]
+mod tests;

--- a/codex-rs/app-server/src/thread_state_spine_ui_manager.rs
+++ b/codex-rs/app-server/src/thread_state_spine_ui_manager.rs
@@ -1,0 +1,647 @@
+use super::*;
+use std::time::Duration;
+
+impl ThreadStateManager {
+    pub(crate) async fn note_spine_ui_listener_generation(
+        &self,
+        thread_id: ThreadId,
+        listener_generation: u64,
+    ) {
+        let mut state = self.state.lock().await;
+        let generation_changed = {
+            let entry = state.threads.entry(thread_id).or_default();
+            if listener_generation < entry.listener_generation {
+                return;
+            }
+            let generation_changed = entry.listener_generation != listener_generation;
+            if generation_changed {
+                entry.spine_ui_terminal_ack = None;
+            }
+            entry.listener_generation = listener_generation;
+            generation_changed
+        };
+        if generation_changed && let Some(route) = state.spine_ui_parent_by_child.get(&thread_id) {
+            route
+                .terminal_tx
+                .send_replace(SpineUiRouteTerminalState::Pending);
+        }
+    }
+
+    pub(crate) async fn note_spine_ui_agent_turn_started(
+        &self,
+        thread_id: ThreadId,
+        listener_generation: u64,
+    ) {
+        let mut state = self.state.lock().await;
+        let Some(entry) = state.threads.get(&thread_id) else {
+            return;
+        };
+        if entry.listener_generation != listener_generation {
+            return;
+        }
+        let stale_children = state
+            .spine_ui_parent_by_child
+            .iter()
+            .filter_map(|(child_thread_id, route)| {
+                (route.parent_thread_id == thread_id).then_some(*child_thread_id)
+            })
+            .collect::<Vec<_>>();
+        for child_thread_id in stale_children {
+            if let Some(route) = state.spine_ui_parent_by_child.remove(&child_thread_id) {
+                route
+                    .terminal_tx
+                    .send_replace(SpineUiRouteTerminalState::Invalidated);
+            }
+        }
+
+        let Some(entry) = state.threads.get_mut(&thread_id) else {
+            return;
+        };
+        entry.spine_ui_terminal_ack = None;
+        if let Some(route) = state.spine_ui_parent_by_child.get(&thread_id) {
+            route
+                .terminal_tx
+                .send_replace(SpineUiRouteTerminalState::Pending);
+        }
+    }
+
+    pub(crate) async fn spine_ui_state_for_thread(
+        &self,
+        thread_id: ThreadId,
+    ) -> Option<SpineUiState> {
+        let thread_state = self
+            .state
+            .lock()
+            .await
+            .threads
+            .get(&thread_id)
+            .map(|entry| entry.state.clone())?;
+        thread_state
+            .lock()
+            .await
+            .current_spine_ui_for_forward()
+            .cloned()
+    }
+
+    pub(crate) async fn register_spine_ui_spawn_progress(
+        &self,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+        progress: &SpineSpawnProgressEvent,
+    ) {
+        let parent_state = self.thread_state(parent_thread_id).await;
+        let baseline_node_ids = Arc::new({
+            let parent_state = parent_state.lock().await;
+            let Some(parent_ui) = parent_state.live_spine_ui(parent_turn_id) else {
+                return;
+            };
+            parent_ui
+                .latest_snapshot()
+                .map(|snapshot| {
+                    snapshot
+                        .nodes
+                        .iter()
+                        .map(|node| node.node_id.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        });
+
+        let new_child_thread_ids =
+            {
+                let mut state = self.state.lock().await;
+                let mut new_child_thread_ids = Vec::new();
+                for task in &progress.tasks {
+                    let terminal_ack = {
+                        let entry = state.threads.entry(task.thread_id).or_default();
+                        entry
+                            .spine_ui_terminal_ack
+                            .clone()
+                            .filter(|ack| entry.listener_generation == ack.listener_generation)
+                    };
+                    if state
+                        .spine_ui_parent_by_child
+                        .get(&task.thread_id)
+                        .is_some_and(|route| {
+                            route.parent_thread_id == parent_thread_id
+                                && route.parent_turn_id == parent_turn_id
+                        })
+                    {
+                        continue;
+                    }
+                    if let Some(previous) = state.spine_ui_parent_by_child.remove(&task.thread_id) {
+                        previous
+                            .terminal_tx
+                            .send_replace(SpineUiRouteTerminalState::Invalidated);
+                    }
+                    state.next_spine_ui_route_generation =
+                        state.next_spine_ui_route_generation.saturating_add(1);
+                    let generation = state.next_spine_ui_route_generation;
+                    let terminal_state =
+                        terminal_ack.map_or(SpineUiRouteTerminalState::Pending, |ack| {
+                            SpineUiRouteTerminalState::Settled(ack.state.map(|state| {
+                                Box::new(state.filtered_for_parent(&baseline_node_ids))
+                            }))
+                        });
+                    state.spine_ui_parent_by_child.insert(
+                        task.thread_id,
+                        SpineUiParentRoute {
+                            parent_thread_id,
+                            parent_turn_id: parent_turn_id.to_string(),
+                            baseline_node_ids: baseline_node_ids.clone(),
+                            generation,
+                            timed_out: false,
+                            queued_revision: None,
+                            last_forwarded_revision: None,
+                            terminal_tx: watch::channel(terminal_state).0,
+                        },
+                    );
+                    new_child_thread_ids.push(task.thread_id);
+                }
+                new_child_thread_ids
+            };
+        for child_thread_id in new_child_thread_ids {
+            self.queue_spine_ui_agent_state(child_thread_id).await;
+        }
+    }
+
+    pub(crate) async fn queue_spine_ui_agent_state(&self, child_thread_id: ThreadId) {
+        self.queue_spine_ui_agent_state_with_kind(child_thread_id, SpineUiAgentForwardKind::Live)
+            .await;
+    }
+
+    pub(crate) async fn queue_spine_ui_agent_terminal_refresh(&self, child_thread_id: ThreadId) {
+        self.queue_spine_ui_agent_state_with_kind(
+            child_thread_id,
+            SpineUiAgentForwardKind::TerminalRefresh,
+        )
+        .await;
+    }
+
+    async fn queue_spine_ui_agent_state_with_kind(
+        &self,
+        child_thread_id: ThreadId,
+        kind: SpineUiAgentForwardKind,
+    ) {
+        let (route, child_state) = {
+            let state = self.state.lock().await;
+            let Some(route) = state
+                .spine_ui_parent_by_child
+                .get(&child_thread_id)
+                .cloned()
+            else {
+                return;
+            };
+            let Some(child_state) = state
+                .threads
+                .get(&child_thread_id)
+                .map(|entry| entry.state.clone())
+            else {
+                return;
+            };
+            (route, child_state)
+        };
+        let child_state = {
+            let child_state = child_state.lock().await;
+            let Some(child_state) = child_state.current_spine_ui_for_forward() else {
+                return;
+            };
+            child_state.filtered_for_parent(&route.baseline_node_ids)
+        };
+        let Some(tx) = self.current_listener_command_tx(route.parent_thread_id) else {
+            return;
+        };
+        let queued_revision = child_state.revision();
+        if kind == SpineUiAgentForwardKind::Live {
+            let mut state = self.state.lock().await;
+            let Some(current) = state.spine_ui_parent_by_child.get_mut(&child_thread_id) else {
+                return;
+            };
+            if current.generation != route.generation
+                || current.queued_revision.is_some()
+                || current
+                    .last_forwarded_revision
+                    .is_some_and(|revision| revision >= queued_revision)
+            {
+                return;
+            }
+            current.queued_revision = Some(queued_revision);
+        } else {
+            let mut state = self.state.lock().await;
+            let Some(current) = state.spine_ui_parent_by_child.get_mut(&child_thread_id) else {
+                return;
+            };
+            if current.generation != route.generation {
+                return;
+            }
+            current
+                .terminal_tx
+                .send_replace(SpineUiRouteTerminalState::Settled(Some(Box::new(
+                    child_state.clone(),
+                ))));
+        }
+        let send_result = tx.send(ThreadListenerCommand::ForwardSpineUiAgentState {
+            child_thread_id,
+            parent_turn_id: route.parent_turn_id,
+            generation: route.generation,
+            state: Some(child_state),
+            terminal: kind == SpineUiAgentForwardKind::TerminalRefresh,
+        });
+        if send_result.is_err() && kind == SpineUiAgentForwardKind::Live {
+            let mut state = self.state.lock().await;
+            if let Some(current) = state.spine_ui_parent_by_child.get_mut(&child_thread_id)
+                && current.generation == route.generation
+                && current.queued_revision == Some(queued_revision)
+            {
+                current.queued_revision = None;
+            }
+        }
+    }
+
+    pub(crate) async fn complete_spine_ui_agent_state_forward(
+        &self,
+        child_thread_id: ThreadId,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+        generation: u64,
+        forwarded_revision: u64,
+    ) {
+        {
+            let mut state = self.state.lock().await;
+            let Some(route) = state.spine_ui_parent_by_child.get_mut(&child_thread_id) else {
+                return;
+            };
+            if route.parent_thread_id != parent_thread_id
+                || route.parent_turn_id != parent_turn_id
+                || route.generation != generation
+                || route.queued_revision != Some(forwarded_revision)
+            {
+                return;
+            }
+            route.queued_revision = None;
+            route.last_forwarded_revision = Some(
+                route
+                    .last_forwarded_revision
+                    .unwrap_or_default()
+                    .max(forwarded_revision),
+            );
+        }
+        self.queue_spine_ui_agent_state(child_thread_id).await;
+    }
+
+    pub(crate) async fn acknowledge_spine_ui_agent_terminal(
+        &self,
+        child_thread_id: ThreadId,
+        listener_generation: u64,
+        terminal_turn_id: &str,
+    ) {
+        let child_state = {
+            let state = self.state.lock().await;
+            let Some(entry) = state.threads.get(&child_thread_id) else {
+                return;
+            };
+            if entry.listener_generation != listener_generation {
+                return;
+            }
+            entry.state.clone()
+        };
+        let terminal_state = {
+            let child_state = child_state.lock().await;
+            if child_state.current_turn_history.has_active_turn()
+                || child_state.listener_generation != listener_generation
+                || child_state.last_terminal_turn_id.as_deref() != Some(terminal_turn_id)
+            {
+                return;
+            }
+            child_state.current_spine_ui_for_forward().cloned()
+        };
+
+        let mut state = self.state.lock().await;
+        {
+            let Some(entry) = state.threads.get_mut(&child_thread_id) else {
+                return;
+            };
+            if entry.listener_generation != listener_generation {
+                return;
+            }
+            entry.spine_ui_terminal_ack = Some(SpineUiTerminalAck {
+                listener_generation,
+                state: terminal_state.clone(),
+            });
+        }
+        let route = state
+            .spine_ui_parent_by_child
+            .get(&child_thread_id)
+            .cloned();
+        let late_terminal = if let Some(route) = route
+            && let Some(current) = state.spine_ui_parent_by_child.get_mut(&child_thread_id)
+            && current.generation == route.generation
+        {
+            let was_timed_out = current.timed_out;
+            let filtered_state = terminal_state
+                .map(|state| Box::new(state.filtered_for_parent(&route.baseline_node_ids)));
+            current
+                .terminal_tx
+                .send_replace(SpineUiRouteTerminalState::Settled(filtered_state.clone()));
+            was_timed_out.then_some((route, filtered_state.map(|state| *state)))
+        } else {
+            None
+        };
+        drop(state);
+
+        if let Some((route, terminal_state)) = late_terminal
+            && let Some(tx) = self.current_listener_command_tx(route.parent_thread_id)
+        {
+            let _ = tx.send(ThreadListenerCommand::ForwardSpineUiAgentState {
+                child_thread_id,
+                parent_turn_id: route.parent_turn_id,
+                generation: route.generation,
+                state: terminal_state,
+                terminal: true,
+            });
+        }
+    }
+
+    pub(crate) async fn wait_for_spine_ui_terminal_children(
+        &self,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+        timeout: Duration,
+    ) -> (
+        Vec<(ThreadId, u64, Option<SpineUiState>)>,
+        Vec<(ThreadId, u64)>,
+    ) {
+        let candidates = {
+            let state = self.state.lock().await;
+            state
+                .spine_ui_parent_by_child
+                .iter()
+                .filter(|(_, route)| {
+                    route.parent_thread_id == parent_thread_id
+                        && route.parent_turn_id == parent_turn_id
+                })
+                .filter_map(|(child_thread_id, route)| {
+                    let child_state = state.threads.get(child_thread_id)?.state.clone();
+                    Some((
+                        *child_thread_id,
+                        route.generation,
+                        route.baseline_node_ids.clone(),
+                        route.terminal_tx.subscribe(),
+                        child_state,
+                    ))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut states = Vec::with_capacity(candidates.len());
+        let mut timed_out = Vec::new();
+        for (child_thread_id, generation, baseline_node_ids, mut terminal_rx, child_state) in
+            candidates
+        {
+            let current = terminal_rx.borrow_and_update().clone();
+            let terminal = if matches!(current, SpineUiRouteTerminalState::Pending) {
+                tokio::time::timeout_at(deadline, async {
+                    loop {
+                        if terminal_rx.changed().await.is_err() {
+                            break SpineUiRouteTerminalState::Invalidated;
+                        }
+                        let state = terminal_rx.borrow_and_update().clone();
+                        if !matches!(state, SpineUiRouteTerminalState::Pending) {
+                            break state;
+                        }
+                    }
+                })
+                .await
+                .ok()
+            } else {
+                Some(current)
+            };
+
+            match terminal {
+                Some(SpineUiRouteTerminalState::Settled(state)) => {
+                    states.push((child_thread_id, generation, state.map(|state| *state)));
+                }
+                Some(SpineUiRouteTerminalState::Invalidated) => {
+                    states.push((child_thread_id, generation, None));
+                }
+                Some(SpineUiRouteTerminalState::TimedOut) => {
+                    timed_out.push((child_thread_id, generation));
+                    states.push((
+                        child_thread_id,
+                        generation,
+                        child_state
+                            .lock()
+                            .await
+                            .current_spine_ui_for_forward()
+                            .map(|state| state.filtered_for_parent(&baseline_node_ids)),
+                    ));
+                }
+                Some(SpineUiRouteTerminalState::Pending) => unreachable!(),
+                None => {
+                    let latest = child_state
+                        .lock()
+                        .await
+                        .current_spine_ui_for_forward()
+                        .map(|state| state.filtered_for_parent(&baseline_node_ids));
+                    match self
+                        .mark_spine_ui_route_timed_out(
+                            child_thread_id,
+                            parent_thread_id,
+                            parent_turn_id,
+                            generation,
+                        )
+                        .await
+                    {
+                        SpineUiRouteTerminalState::Settled(state) => {
+                            states.push((child_thread_id, generation, state.map(|state| *state)));
+                        }
+                        SpineUiRouteTerminalState::Invalidated => {
+                            states.push((child_thread_id, generation, None));
+                        }
+                        SpineUiRouteTerminalState::TimedOut => {
+                            timed_out.push((child_thread_id, generation));
+                            states.push((child_thread_id, generation, latest));
+                        }
+                        SpineUiRouteTerminalState::Pending => unreachable!(),
+                    }
+                }
+            }
+        }
+        (states, timed_out)
+    }
+
+    async fn mark_spine_ui_route_timed_out(
+        &self,
+        child_thread_id: ThreadId,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+        generation: u64,
+    ) -> SpineUiRouteTerminalState {
+        let mut state = self.state.lock().await;
+        let Some(route) = state.spine_ui_parent_by_child.get_mut(&child_thread_id) else {
+            return SpineUiRouteTerminalState::Invalidated;
+        };
+        if route.parent_thread_id != parent_thread_id
+            || route.parent_turn_id != parent_turn_id
+            || route.generation != generation
+        {
+            return SpineUiRouteTerminalState::Invalidated;
+        }
+        let terminal = route.terminal_tx.borrow().clone();
+        if matches!(terminal, SpineUiRouteTerminalState::Pending) {
+            route.timed_out = true;
+            route
+                .terminal_tx
+                .send_replace(SpineUiRouteTerminalState::TimedOut);
+            SpineUiRouteTerminalState::TimedOut
+        } else {
+            terminal
+        }
+    }
+
+    pub(crate) async fn complete_spine_ui_late_terminal(
+        &self,
+        child_thread_id: ThreadId,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+        generation: u64,
+    ) {
+        let mut state = self.state.lock().await;
+        let should_remove = state
+            .spine_ui_parent_by_child
+            .get(&child_thread_id)
+            .is_some_and(|route| {
+                route.parent_thread_id == parent_thread_id
+                    && route.parent_turn_id == parent_turn_id
+                    && route.generation == generation
+                    && route.timed_out
+            });
+        if should_remove {
+            state.spine_ui_parent_by_child.remove(&child_thread_id);
+        }
+    }
+
+    pub(crate) async fn spine_ui_route_is_current(
+        &self,
+        child_thread_id: ThreadId,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+        generation: u64,
+    ) -> bool {
+        self.state
+            .lock()
+            .await
+            .spine_ui_parent_by_child
+            .get(&child_thread_id)
+            .is_some_and(|route| {
+                route.parent_thread_id == parent_thread_id
+                    && route.parent_turn_id == parent_turn_id
+                    && route.generation == generation
+            })
+    }
+
+    pub(crate) async fn clear_spine_ui_parent_routes(
+        &self,
+        parent_thread_id: ThreadId,
+        parent_turn_id: &str,
+    ) {
+        let mut state = self.state.lock().await;
+        let child_thread_ids = state
+            .spine_ui_parent_by_child
+            .iter()
+            .filter_map(|(child_thread_id, route)| {
+                (route.parent_thread_id == parent_thread_id
+                    && route.parent_turn_id == parent_turn_id
+                    && !route.timed_out
+                    && !route.has_nested_sync_timeout())
+                .then_some(*child_thread_id)
+            })
+            .collect::<Vec<_>>();
+        for child_thread_id in child_thread_ids {
+            if let Some(route) = state.spine_ui_parent_by_child.remove(&child_thread_id) {
+                route
+                    .terminal_tx
+                    .send_replace(SpineUiRouteTerminalState::Invalidated);
+            }
+        }
+    }
+
+    pub(crate) async fn clear_all_spine_ui_routes_for_thread(&self, thread_id: ThreadId) {
+        self.clear_spine_ui_routes_for_thread(thread_id, None).await;
+    }
+
+    pub(crate) async fn clear_spine_ui_routes_for_listener_exit(
+        &self,
+        thread_id: ThreadId,
+        listener_generation: u64,
+    ) {
+        self.clear_spine_ui_routes_for_thread(thread_id, Some(listener_generation))
+            .await;
+    }
+
+    async fn clear_spine_ui_routes_for_thread(
+        &self,
+        thread_id: ThreadId,
+        listener_generation: Option<u64>,
+    ) {
+        let invalidation_targets = {
+            let mut state = self.state.lock().await;
+            if listener_generation.is_some_and(|listener_generation| {
+                state
+                    .threads
+                    .get(&thread_id)
+                    .is_none_or(|entry| entry.listener_generation != listener_generation)
+            }) {
+                return;
+            }
+            if let Some(entry) = state.threads.get_mut(&thread_id) {
+                entry.spine_ui_terminal_ack = None;
+            }
+            let routes = state
+                .spine_ui_parent_by_child
+                .iter()
+                .filter_map(|(child_thread_id, route)| {
+                    (*child_thread_id == thread_id || route.parent_thread_id == thread_id)
+                        .then_some((*child_thread_id, route.clone()))
+                })
+                .collect::<Vec<_>>();
+            let mut targets = Vec::new();
+            for (child_thread_id, route) in routes {
+                state.spine_ui_parent_by_child.remove(&child_thread_id);
+                route
+                    .terminal_tx
+                    .send_replace(SpineUiRouteTerminalState::Invalidated);
+                if child_thread_id == thread_id {
+                    targets.push((route.parent_thread_id, child_thread_id, route.generation));
+                }
+            }
+            targets
+        };
+
+        for (parent_thread_id, child_thread_id, generation) in invalidation_targets {
+            let parent_state = {
+                let state = self.state.lock().await;
+                state
+                    .threads
+                    .get(&parent_thread_id)
+                    .map(|entry| entry.state.clone())
+            };
+            let Some(parent_state) = parent_state else {
+                continue;
+            };
+            let active = {
+                let mut parent_state = parent_state.lock().await;
+                parent_state
+                    .invalidate_spine_ui_agent_state(child_thread_id, generation)
+                    .then(|| parent_state.active_spine_ui_snapshot())
+                    .flatten()
+            };
+            if let Some((turn_id, state)) = active
+                && let Some(tx) = self.current_listener_command_tx(parent_thread_id)
+            {
+                let _ = tx.send(ThreadListenerCommand::EmitSpineUiInvalidation { turn_id, state });
+            }
+        }
+    }
+}

--- a/codex-rs/app-server/src/thread_state_spine_ui_tests.rs
+++ b/codex-rs/app-server/src/thread_state_spine_ui_tests.rs
@@ -1,0 +1,1147 @@
+use super::*;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::AgentStatus;
+use codex_protocol::protocol::SpineSpawnTaskProgress;
+use codex_protocol::protocol::SpineTreeNodeKind;
+use codex_protocol::protocol::SpineTreeNodeSnapshot;
+use codex_protocol::protocol::SpineTreeNodeStatus;
+use codex_protocol::protocol::TurnCompleteEvent;
+use codex_protocol::protocol::TurnStartedEvent;
+use std::time::Duration;
+
+fn tree_snapshot(sequence: u64, active_node_id: &str, changed: bool) -> SpineTreeUpdateEvent {
+    let mut nodes = vec![SpineTreeNodeSnapshot {
+        node_id: "1".to_string(),
+        parent_id: None,
+        kind: SpineTreeNodeKind::RootEpoch,
+        status: SpineTreeNodeStatus::Opened,
+        summary: None,
+        memory_summary: Some("internal".to_string()),
+        spawn_outcome: None,
+        start: 0,
+        end: Some(10),
+        context_pressure: None,
+    }];
+    nodes.push(SpineTreeNodeSnapshot {
+        node_id: "1.1".to_string(),
+        parent_id: Some("1".to_string()),
+        kind: SpineTreeNodeKind::Task,
+        status: if changed {
+            SpineTreeNodeStatus::Closed
+        } else {
+            SpineTreeNodeStatus::Live
+        },
+        summary: Some("first task".to_string()),
+        memory_summary: Some("internal".to_string()),
+        spawn_outcome: None,
+        start: 1,
+        end: Some(11),
+        context_pressure: None,
+    });
+    if active_node_id == "1.2" {
+        nodes.push(SpineTreeNodeSnapshot {
+            node_id: "1.2".to_string(),
+            parent_id: Some("1".to_string()),
+            kind: SpineTreeNodeKind::Task,
+            status: SpineTreeNodeStatus::Live,
+            summary: Some("second task".to_string()),
+            memory_summary: None,
+            spawn_outcome: None,
+            start: 2,
+            end: None,
+            context_pressure: None,
+        });
+    }
+    SpineTreeUpdateEvent {
+        snapshot_seq: sequence,
+        active_node_id: active_node_id.to_string(),
+        nodes,
+        settled_spawn_call_ids: Vec::new(),
+    }
+}
+
+fn growing_tree_snapshot(sequence: u64, task_count: u64) -> SpineTreeUpdateEvent {
+    let mut nodes = vec![SpineTreeNodeSnapshot {
+        node_id: "1".to_string(),
+        parent_id: None,
+        kind: SpineTreeNodeKind::RootEpoch,
+        status: SpineTreeNodeStatus::Opened,
+        summary: None,
+        memory_summary: None,
+        spawn_outcome: None,
+        start: 0,
+        end: None,
+        context_pressure: None,
+    }];
+    nodes.extend((1..=task_count).map(|ordinal| SpineTreeNodeSnapshot {
+        node_id: format!("1.{ordinal}"),
+        parent_id: Some("1".to_string()),
+        kind: SpineTreeNodeKind::Task,
+        status: SpineTreeNodeStatus::Live,
+        summary: Some(format!("task {ordinal}")),
+        memory_summary: None,
+        spawn_outcome: None,
+        start: ordinal,
+        end: None,
+        context_pressure: None,
+    }));
+    SpineTreeUpdateEvent {
+        snapshot_seq: sequence,
+        active_node_id: format!("1.{task_count}"),
+        nodes,
+        settled_spawn_call_ids: Vec::new(),
+    }
+}
+
+fn turn_started(turn_id: &str) -> EventMsg {
+    EventMsg::TurnStarted(TurnStartedEvent {
+        turn_id: turn_id.to_string(),
+        trace_id: None,
+        started_at: None,
+        model_context_window: None,
+        collaboration_mode_kind: Default::default(),
+    })
+}
+
+fn spine_call() -> EventMsg {
+    EventMsg::RawResponseItem(codex_protocol::protocol::RawResponseItemEvent {
+        item: ResponseItem::FunctionCall {
+            id: None,
+            name: "open".to_string(),
+            namespace: Some("spine".to_string()),
+            arguments: "{}".to_string(),
+            call_id: "call-spine".to_string(),
+            internal_chat_message_metadata_passthrough: None,
+        },
+    })
+}
+
+fn turn_complete(turn_id: &str) -> EventMsg {
+    EventMsg::TurnComplete(TurnCompleteEvent {
+        turn_id: turn_id.to_string(),
+        last_agent_message: None,
+        completed_at: None,
+        duration_ms: None,
+        time_to_first_token_ms: None,
+    })
+}
+
+fn spawn_progress(child_thread_id: ThreadId) -> SpineSpawnProgressEvent {
+    SpineSpawnProgressEvent {
+        call_id: format!("spawn-{child_thread_id}"),
+        tasks: vec![SpineSpawnTaskProgress {
+            ordinal: 0,
+            summary: "Run child agent".to_string(),
+            thread_id: child_thread_id,
+            agent_path: None,
+            status: AgentStatus::Running,
+        }],
+    }
+}
+
+fn activate_spine_turn(state: &mut ThreadState, turn_id: &str, sequence: u64) {
+    state.track_current_turn_event(turn_id, &turn_started(turn_id));
+    state.track_current_turn_event(turn_id, &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(sequence, "1.1", false));
+}
+
+fn finish_spine_turn(state: &mut ThreadState, turn_id: &str) {
+    state.track_current_turn_event(turn_id, &turn_complete(turn_id));
+    state.take_turn_summary();
+}
+
+async fn register_test_route(
+    manager: &ThreadStateManager,
+    parent_thread_id: ThreadId,
+    parent_turn_id: &str,
+    child_thread_id: ThreadId,
+) -> SpineSpawnProgressEvent {
+    let progress = spawn_progress(child_thread_id);
+    let parent_state = manager.thread_state(parent_thread_id).await;
+    {
+        let mut state = parent_state.lock().await;
+        activate_spine_turn(&mut state, parent_turn_id, 1);
+        state.record_spine_ui_spawn_progress(progress.clone());
+    }
+    manager
+        .register_spine_ui_spawn_progress(parent_thread_id, parent_turn_id, &progress)
+        .await;
+    progress
+}
+
+#[test]
+fn each_turn_keeps_the_complete_tree() {
+    let mut state = ThreadState::default();
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    let first = state.take_turn_summary();
+    assert_eq!(first.spine_ui.latest_snapshot().unwrap().nodes.len(), 2);
+
+    state.track_current_turn_event("turn-2", &turn_started("turn-2"));
+    state.track_current_turn_event("turn-2", &spine_call());
+    assert!(state.turn_summary.spine_ui.latest_snapshot().is_none());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.2", false));
+
+    let second = state
+        .turn_summary
+        .spine_ui
+        .latest_snapshot()
+        .expect("second turn snapshot");
+    let ids = second
+        .nodes
+        .iter()
+        .map(|node| node.node_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["1", "1.1", "1.2"]);
+    assert_eq!(second.active_node_id, "1.2");
+}
+
+#[test]
+fn a_changed_old_node_is_kept_in_the_complete_tree() {
+    let mut state = ThreadState::default();
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    state.take_turn_summary();
+
+    state.track_current_turn_event("turn-2", &turn_started("turn-2"));
+    state.track_current_turn_event("turn-2", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(2, "1.1", true));
+
+    let second = state
+        .turn_summary
+        .spine_ui
+        .latest_snapshot()
+        .expect("second turn snapshot");
+    assert_eq!(second.nodes.len(), 2);
+    assert_eq!(second.nodes[1].node_id, "1.1");
+    assert_eq!(second.nodes[1].status, SpineTreeNodeStatus::Closed);
+}
+
+#[test]
+fn snapshot_without_an_active_spine_turn_seeds_the_next_complete_tree() {
+    let mut state = ThreadState::default();
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    assert!(state.live_spine_ui("turn-1").is_none());
+
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(2, "1.2", false));
+    let snapshot = state
+        .turn_summary
+        .spine_ui
+        .latest_snapshot()
+        .expect("live snapshot");
+    assert_eq!(snapshot.nodes.len(), 3);
+    assert_eq!(snapshot.active_node_id, "1.2");
+}
+
+#[test]
+fn every_live_card_contains_the_complete_tree_across_many_turns() {
+    let mut state = ThreadState::default();
+    let mut total_node_count = 0;
+
+    for turn in 1..=32 {
+        let turn_id = format!("turn-{turn}");
+        state.track_current_turn_event(&turn_id, &turn_started(&turn_id));
+        state.track_current_turn_event(&turn_id, &spine_call());
+        state.record_spine_ui_snapshot(growing_tree_snapshot(turn, turn));
+
+        let node_count = state
+            .turn_summary
+            .spine_ui
+            .latest_snapshot()
+            .expect("complete snapshot")
+            .nodes
+            .len();
+        assert_eq!(node_count, turn as usize + 1);
+        total_node_count += node_count;
+
+        finish_spine_turn(&mut state, &turn_id);
+    }
+
+    assert_eq!(total_node_count, 560);
+}
+
+#[test]
+fn a_turn_without_spine_does_not_discard_the_next_complete_tree() {
+    let mut state = ThreadState::default();
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    finish_spine_turn(&mut state, "turn-1");
+
+    state.track_current_turn_event("turn-2", &turn_started("turn-2"));
+    finish_spine_turn(&mut state, "turn-2");
+
+    state.track_current_turn_event("turn-3", &turn_started("turn-3"));
+    state.track_current_turn_event("turn-3", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.2", false));
+
+    let snapshot = state
+        .turn_summary
+        .spine_ui
+        .latest_snapshot()
+        .expect("complete tree after an ordinary turn");
+    assert_eq!(snapshot.nodes.len(), 3);
+    assert_eq!(snapshot.active_node_id, "1.2");
+}
+
+#[test]
+fn spawned_agent_subtrees_are_carried_into_the_next_complete_tree() {
+    let mut state = ThreadState::default();
+    let child_thread_id = ThreadId::new();
+
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    assert!(state.record_spine_ui_spawn_progress(spawn_progress(child_thread_id)));
+
+    let mut child_state = SpineUiState::default();
+    child_state.record_snapshot(tree_snapshot(1, "1.1", false));
+    assert!(state.record_spine_ui_agent_state(child_thread_id, 1, child_state));
+    finish_spine_turn(&mut state, "turn-1");
+
+    state.track_current_turn_event("turn-2", &turn_started("turn-2"));
+    state.track_current_turn_event("turn-2", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.2", false));
+
+    let content = state
+        .turn_summary
+        .spine_ui
+        .structured_content()
+        .expect("second complete tree");
+    assert_eq!(content["snapshot"]["nodes"].as_array().unwrap().len(), 3);
+    assert_eq!(content["spawnCalls"].as_array().unwrap().len(), 1);
+    assert_eq!(content["agentSubtrees"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        content["agentSubtrees"][0]["threadId"],
+        serde_json::json!(child_thread_id)
+    );
+}
+
+#[test]
+fn clearing_the_listener_drops_the_in_memory_complete_tree() {
+    let mut state = ThreadState::default();
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    finish_spine_turn(&mut state, "turn-1");
+
+    state.clear_listener();
+    state.track_current_turn_event("turn-2", &turn_started("turn-2"));
+    state.track_current_turn_event("turn-2", &spine_call());
+
+    assert!(state.turn_summary.spine_ui.latest_snapshot().is_none());
+}
+
+#[test]
+fn replacing_the_listener_drops_the_in_memory_complete_tree() {
+    let mut state = ThreadState::default();
+    state.track_current_turn_event("turn-1", &turn_started("turn-1"));
+    state.track_current_turn_event("turn-1", &spine_call());
+    state.record_spine_ui_snapshot(tree_snapshot(1, "1.1", false));
+    finish_spine_turn(&mut state, "turn-1");
+
+    let (first_cancel_tx, mut first_cancel_rx) = oneshot::channel();
+    state.replace_listener_cancel_tx(first_cancel_tx);
+    assert!(
+        state
+            .spine_ui_runtime
+            .cumulative
+            .latest_snapshot()
+            .is_some()
+    );
+
+    let (replacement_cancel_tx, _replacement_cancel_rx) = oneshot::channel();
+    state.replace_listener_cancel_tx(replacement_cancel_tx);
+    assert_eq!(first_cancel_rx.try_recv(), Ok(()));
+
+    state.track_current_turn_event("turn-2", &turn_started("turn-2"));
+    state.track_current_turn_event("turn-2", &spine_call());
+    assert!(state.turn_summary.spine_ui.latest_snapshot().is_none());
+}
+
+#[tokio::test]
+async fn terminal_barrier_waits_for_the_matching_child_ack() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 7);
+    }
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+
+    let waiter_manager = manager.clone();
+    let waiter = tokio::spawn(async move {
+        waiter_manager
+            .wait_for_spine_ui_terminal_children(
+                parent_thread_id,
+                "parent-turn",
+                Duration::from_secs(2),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    {
+        let mut state = child_state.lock().await;
+        finish_spine_turn(&mut state, "child-turn");
+    }
+    manager
+        .acknowledge_spine_ui_agent_terminal(child_thread_id, 0, "child-turn")
+        .await;
+
+    let (states, timed_out) = waiter.await.expect("terminal barrier task");
+    assert!(timed_out.is_empty());
+    assert_eq!(states.len(), 1);
+    assert_eq!(states[0].0, child_thread_id);
+    assert_eq!(
+        states[0]
+            .2
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .map(|snapshot| snapshot.snapshot_seq),
+        Some(7)
+    );
+    assert!(
+        states[0]
+            .2
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .is_some_and(|snapshot| snapshot.nodes.is_empty())
+    );
+}
+
+#[tokio::test]
+async fn forwarded_agent_state_excludes_nodes_inherited_from_the_parent() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        state.track_current_turn_event("child-turn", &turn_started("child-turn"));
+        state.track_current_turn_event("child-turn", &spine_call());
+        let mut child_snapshot = tree_snapshot(2, "1.1", false);
+        child_snapshot.active_node_id = "1.1.1".to_string();
+        child_snapshot.nodes.push(SpineTreeNodeSnapshot {
+            node_id: "1.1.1".to_string(),
+            parent_id: Some("1.1".to_string()),
+            kind: SpineTreeNodeKind::Task,
+            status: SpineTreeNodeStatus::Live,
+            summary: Some("child-only task".to_string()),
+            memory_summary: None,
+            spawn_outcome: None,
+            start: 2,
+            end: None,
+            context_pressure: None,
+        });
+        state.record_spine_ui_snapshot(child_snapshot);
+    }
+    let (listener_tx, mut listener_rx) = mpsc::unbounded_channel();
+    manager.register_listener_command_tx(parent_thread_id, listener_tx);
+
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        state: Some(forwarded),
+        ..
+    } = listener_rx.recv().await.expect("initial child state")
+    else {
+        panic!("expected initial child state");
+    };
+    let forwarded_node_ids = forwarded
+        .latest_snapshot()
+        .expect("forwarded child snapshot")
+        .nodes
+        .iter()
+        .map(|node| node.node_id.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(forwarded_node_ids, vec!["1.1.1"]);
+}
+
+#[tokio::test]
+async fn repeated_progress_is_deduplicated_and_newer_states_are_coalesced() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 2);
+    }
+    let (listener_tx, mut listener_rx) = mpsc::unbounded_channel();
+    manager.register_listener_command_tx(parent_thread_id, listener_tx);
+
+    let progress =
+        register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        generation,
+        state: Some(initial_state),
+        ..
+    } = listener_rx.recv().await.expect("initial child state")
+    else {
+        panic!("expected initial child state");
+    };
+    manager
+        .complete_spine_ui_agent_state_forward(
+            child_thread_id,
+            parent_thread_id,
+            "parent-turn",
+            generation,
+            initial_state.revision(),
+        )
+        .await;
+
+    manager
+        .register_spine_ui_spawn_progress(parent_thread_id, "parent-turn", &progress)
+        .await;
+    manager.queue_spine_ui_agent_state(child_thread_id).await;
+
+    assert!(matches!(
+        listener_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    {
+        let mut state = child_state.lock().await;
+        state.record_spine_ui_snapshot(tree_snapshot(3, "1.2", false));
+    }
+    manager.queue_spine_ui_agent_state(child_thread_id).await;
+    manager.queue_spine_ui_agent_state(child_thread_id).await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        state: Some(forwarded),
+        ..
+    } = listener_rx.recv().await.expect("updated child state")
+    else {
+        panic!("expected updated child state");
+    };
+    {
+        let mut state = child_state.lock().await;
+        state.record_spine_ui_snapshot(tree_snapshot(4, "1.1", false));
+    }
+    manager.queue_spine_ui_agent_state(child_thread_id).await;
+    manager.queue_spine_ui_agent_state(child_thread_id).await;
+    assert!(matches!(
+        listener_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    manager
+        .complete_spine_ui_agent_state_forward(
+            child_thread_id,
+            parent_thread_id,
+            "parent-turn",
+            generation,
+            forwarded.revision(),
+        )
+        .await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        state: Some(coalesced),
+        ..
+    } = listener_rx
+        .recv()
+        .await
+        .expect("coalesced latest child state")
+    else {
+        panic!("expected coalesced latest child state");
+    };
+    assert_eq!(
+        coalesced
+            .latest_snapshot()
+            .expect("coalesced snapshot")
+            .snapshot_seq,
+        4
+    );
+}
+
+#[tokio::test]
+async fn terminal_barrier_observes_an_ack_before_route_registration() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 9);
+        finish_spine_turn(&mut state, "child-turn");
+    }
+    manager
+        .acknowledge_spine_ui_agent_terminal(child_thread_id, 0, "child-turn")
+        .await;
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+
+    let (states, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    assert!(timed_out.is_empty());
+    assert_eq!(
+        states[0]
+            .2
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .map(|snapshot| snapshot.snapshot_seq),
+        Some(9)
+    );
+    assert!(
+        states[0]
+            .2
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .is_some_and(|snapshot| snapshot.nodes.is_empty())
+    );
+
+    manager
+        .note_spine_ui_agent_turn_started(child_thread_id, 0)
+        .await;
+    let (_, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    assert_eq!(
+        timed_out
+            .iter()
+            .map(|(thread_id, _)| *thread_id)
+            .collect::<Vec<_>>(),
+        vec![child_thread_id]
+    );
+}
+
+#[tokio::test]
+#[expect(
+    clippy::await_holding_invalid_type,
+    reason = "the test deliberately holds both locks to reproduce the interleaving"
+)]
+async fn terminal_ack_settles_a_route_registered_while_reading_child_state() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 10);
+        finish_spine_turn(&mut state, "child-turn");
+    }
+
+    let child_guard = child_state.lock().await;
+    let manager_guard = manager.state.lock().await;
+    let ack_manager = manager.clone();
+    let ack = tokio::spawn(async move {
+        ack_manager
+            .acknowledge_spine_ui_agent_terminal(child_thread_id, 0, "child-turn")
+            .await;
+    });
+    tokio::task::yield_now().await;
+    drop(manager_guard);
+    drop(manager.state.lock().await);
+
+    let route_manager = manager.clone();
+    let route = tokio::spawn(async move {
+        register_test_route(
+            &route_manager,
+            parent_thread_id,
+            "parent-turn",
+            child_thread_id,
+        )
+        .await;
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if manager
+                .state
+                .lock()
+                .await
+                .spine_ui_parent_by_child
+                .contains_key(&child_thread_id)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("route registration");
+
+    drop(child_guard);
+    ack.await.expect("terminal ack task");
+    route.await.expect("route registration task");
+
+    let (states, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    assert!(timed_out.is_empty());
+    assert_eq!(states.len(), 1);
+    assert_eq!(states[0].0, child_thread_id);
+    assert_eq!(
+        states[0]
+            .2
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .map(|snapshot| snapshot.snapshot_seq),
+        Some(10)
+    );
+}
+
+#[tokio::test]
+async fn terminal_barrier_rejects_an_ack_from_a_stale_listener() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        state.listener_generation = 2;
+        activate_spine_turn(&mut state, "child-turn", 4);
+    }
+    manager
+        .note_spine_ui_listener_generation(child_thread_id, 2)
+        .await;
+    manager
+        .note_spine_ui_listener_generation(child_thread_id, 1)
+        .await;
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        finish_spine_turn(&mut state, "child-turn");
+    }
+
+    manager
+        .acknowledge_spine_ui_agent_terminal(child_thread_id, 1, "child-turn")
+        .await;
+    let (_, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    assert_eq!(
+        timed_out
+            .iter()
+            .map(|(thread_id, _)| *thread_id)
+            .collect::<Vec<_>>(),
+        vec![child_thread_id]
+    );
+
+    manager
+        .acknowledge_spine_ui_agent_terminal(child_thread_id, 2, "child-turn")
+        .await;
+    let (_, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    assert!(timed_out.is_empty());
+}
+
+#[tokio::test]
+async fn stale_turn_started_does_not_remove_routes_owned_by_a_new_listener() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    manager
+        .note_spine_ui_listener_generation(parent_thread_id, 2)
+        .await;
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    let (_, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    let generation = timed_out[0].1;
+
+    manager
+        .note_spine_ui_agent_turn_started(parent_thread_id, 1)
+        .await;
+
+    assert!(
+        manager
+            .spine_ui_route_is_current(
+                child_thread_id,
+                parent_thread_id,
+                "parent-turn",
+                generation,
+            )
+            .await
+    );
+}
+
+#[tokio::test]
+async fn timed_out_child_can_refresh_the_latest_terminal_card() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 5);
+    }
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    let (states, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    let generation = states[0].1;
+    assert_eq!(timed_out, vec![(child_thread_id, generation)]);
+    assert!(
+        states[0]
+            .2
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .is_some_and(|snapshot| snapshot.nodes.is_empty())
+    );
+
+    let parent_state = manager.thread_state(parent_thread_id).await;
+    {
+        let mut state = parent_state.lock().await;
+        assert!(state.record_spine_ui_agent_state(
+            child_thread_id,
+            generation,
+            states[0].2.clone().expect("latest child state"),
+        ));
+        assert!(state.mark_spine_ui_agent_sync_timeout(child_thread_id, generation));
+        finish_spine_turn(&mut state, "parent-turn");
+    }
+    for connection_id in [ConnectionId(7), ConnectionId(8)] {
+        manager
+            .connection_initialized(connection_id, ConnectionCapabilities::default())
+            .await;
+        manager
+            .try_ensure_connection_subscribed(
+                parent_thread_id,
+                connection_id,
+                /*experimental_raw_events*/ false,
+            )
+            .await
+            .expect("connection should subscribe");
+    }
+    let connection_ids = manager.subscribed_connection_ids(parent_thread_id).await;
+    parent_state
+        .lock()
+        .await
+        .set_spine_ui_terminal_connection_ids("parent-turn", &connection_ids);
+    assert!(
+        manager
+            .unsubscribe_connection_from_thread(parent_thread_id, ConnectionId(8))
+            .await
+    );
+    let (listener_tx, mut listener_rx) = mpsc::unbounded_channel();
+    manager.register_listener_command_tx(parent_thread_id, listener_tx);
+
+    {
+        let mut state = child_state.lock().await;
+        finish_spine_turn(&mut state, "child-turn");
+    }
+    manager
+        .acknowledge_spine_ui_agent_terminal(child_thread_id, 0, "child-turn")
+        .await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        generation: forwarded_generation,
+        state: terminal_state,
+        terminal,
+        ..
+    } = listener_rx.recv().await.expect("late terminal forward")
+    else {
+        panic!("expected late terminal forward");
+    };
+    assert_eq!(forwarded_generation, generation);
+    assert!(terminal);
+    assert!(
+        terminal_state
+            .as_ref()
+            .and_then(SpineUiState::latest_snapshot)
+            .is_some_and(|snapshot| snapshot.nodes.is_empty())
+    );
+
+    let refresh = parent_state
+        .lock()
+        .await
+        .record_completed_spine_ui_agent_terminal(
+            "parent-turn",
+            child_thread_id,
+            generation,
+            terminal_state,
+        )
+        .expect("late terminal refresh");
+    let content = refresh
+        .state
+        .structured_content()
+        .expect("refreshed terminal card");
+    assert_eq!(refresh.connection_ids, vec![ConnectionId(7)]);
+    assert_ne!(
+        content["spawnCalls"][0]["tasks"][0]["status"],
+        serde_json::json!("error")
+    );
+
+    manager
+        .complete_spine_ui_late_terminal(
+            child_thread_id,
+            parent_thread_id,
+            "parent-turn",
+            generation,
+        )
+        .await;
+    assert!(
+        !manager
+            .spine_ui_route_is_current(
+                child_thread_id,
+                parent_thread_id,
+                "parent-turn",
+                generation,
+            )
+            .await
+    );
+}
+
+#[tokio::test]
+async fn parent_next_turn_drops_a_timed_out_route() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    let (states, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    let generation = states[0].1;
+    assert_eq!(timed_out, vec![(child_thread_id, generation)]);
+
+    manager
+        .note_spine_ui_agent_turn_started(parent_thread_id, 0)
+        .await;
+    assert!(
+        !manager
+            .spine_ui_route_is_current(
+                child_thread_id,
+                parent_thread_id,
+                "parent-turn",
+                generation,
+            )
+            .await
+    );
+}
+
+#[tokio::test]
+async fn parent_route_is_retained_while_a_nested_agent_can_report_late_terminal() {
+    let manager = ThreadStateManager::new();
+    let ancestor_thread_id = ThreadId::new();
+    let parent_thread_id = ThreadId::new();
+    let nested_child_thread_id = ThreadId::new();
+    let ancestor_state = manager.thread_state(ancestor_thread_id).await;
+    let parent_state = manager.thread_state(parent_thread_id).await;
+    {
+        let mut state = parent_state.lock().await;
+        activate_spine_turn(&mut state, "parent-turn", 2);
+        state.record_spine_ui_spawn_progress(spawn_progress(nested_child_thread_id));
+        assert!(state.mark_spine_ui_agent_sync_timeout(nested_child_thread_id, 1));
+        finish_spine_turn(&mut state, "parent-turn");
+    }
+    manager
+        .acknowledge_spine_ui_agent_terminal(parent_thread_id, 0, "parent-turn")
+        .await;
+    let (listener_tx, mut listener_rx) = mpsc::unbounded_channel();
+    manager.register_listener_command_tx(ancestor_thread_id, listener_tx);
+
+    register_test_route(
+        &manager,
+        ancestor_thread_id,
+        "ancestor-turn",
+        parent_thread_id,
+    )
+    .await;
+    let (states, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(ancestor_thread_id, "ancestor-turn", Duration::ZERO)
+        .await;
+    assert!(timed_out.is_empty());
+    let generation = states[0].1;
+    {
+        let mut state = ancestor_state.lock().await;
+        assert!(state.record_spine_ui_agent_state(
+            parent_thread_id,
+            generation,
+            states[0].2.clone().expect("parent terminal state"),
+        ));
+        finish_spine_turn(&mut state, "ancestor-turn");
+    }
+    let ThreadListenerCommand::ForwardSpineUiAgentState { .. } =
+        listener_rx.recv().await.expect("initial parent state")
+    else {
+        panic!("expected initial parent state");
+    };
+    manager
+        .clear_spine_ui_parent_routes(ancestor_thread_id, "ancestor-turn")
+        .await;
+
+    assert!(
+        manager
+            .spine_ui_route_is_current(
+                parent_thread_id,
+                ancestor_thread_id,
+                "ancestor-turn",
+                generation,
+            )
+            .await
+    );
+
+    let parent_refresh = parent_state
+        .lock()
+        .await
+        .record_completed_spine_ui_agent_terminal(
+            "parent-turn",
+            nested_child_thread_id,
+            1,
+            Some(SpineUiState::default()),
+        )
+        .expect("nested late terminal refresh");
+    assert!(!parent_refresh.state.has_agent_sync_timeout());
+    manager
+        .queue_spine_ui_agent_terminal_refresh(parent_thread_id)
+        .await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        state: Some(parent_terminal_state),
+        terminal,
+        ..
+    } = listener_rx.recv().await.expect("ancestor terminal refresh")
+    else {
+        panic!("expected ancestor terminal refresh");
+    };
+    assert!(terminal);
+
+    let ancestor_refresh = ancestor_state
+        .lock()
+        .await
+        .record_completed_spine_ui_agent_terminal(
+            "ancestor-turn",
+            parent_thread_id,
+            generation,
+            Some(parent_terminal_state),
+        )
+        .expect("ancestor late terminal refresh");
+    assert!(!ancestor_refresh.state.has_agent_sync_timeout());
+}
+
+#[tokio::test]
+async fn listener_exit_clears_only_routes_owned_by_its_generation() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    let (states, _) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    let route_generation = states[0].1;
+    manager
+        .note_spine_ui_listener_generation(child_thread_id, 2)
+        .await;
+
+    manager
+        .clear_spine_ui_routes_for_listener_exit(child_thread_id, 1)
+        .await;
+    assert!(
+        manager
+            .spine_ui_route_is_current(
+                child_thread_id,
+                parent_thread_id,
+                "parent-turn",
+                route_generation,
+            )
+            .await
+    );
+
+    manager
+        .clear_spine_ui_routes_for_listener_exit(child_thread_id, 2)
+        .await;
+    assert!(
+        !manager
+            .spine_ui_route_is_current(
+                child_thread_id,
+                parent_thread_id,
+                "parent-turn",
+                route_generation,
+            )
+            .await
+    );
+}
+
+#[tokio::test]
+async fn rollback_invalidates_the_route_and_a_replacement_gets_a_new_generation() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 3);
+    }
+    let (listener_tx, mut listener_rx) = mpsc::unbounded_channel();
+    manager.register_listener_command_tx(parent_thread_id, listener_tx);
+    let progress =
+        register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        generation: first_generation,
+        state: Some(forwarded),
+        ..
+    } = listener_rx.recv().await.expect("initial child state")
+    else {
+        panic!("expected initial child state");
+    };
+    let parent_state = manager.thread_state(parent_thread_id).await;
+    assert!(parent_state.lock().await.record_spine_ui_agent_state(
+        child_thread_id,
+        first_generation,
+        forwarded,
+    ));
+
+    manager
+        .clear_all_spine_ui_routes_for_thread(child_thread_id)
+        .await;
+    let ThreadListenerCommand::EmitSpineUiInvalidation { .. } =
+        listener_rx.recv().await.expect("rollback invalidation")
+    else {
+        panic!("expected rollback invalidation");
+    };
+    assert!(
+        !manager
+            .spine_ui_route_is_current(
+                child_thread_id,
+                parent_thread_id,
+                "parent-turn",
+                first_generation,
+            )
+            .await
+    );
+
+    manager
+        .register_spine_ui_spawn_progress(parent_thread_id, "parent-turn", &progress)
+        .await;
+    let ThreadListenerCommand::ForwardSpineUiAgentState {
+        generation: second_generation,
+        ..
+    } = listener_rx.recv().await.expect("replacement child state")
+    else {
+        panic!("expected replacement child state");
+    };
+    assert!(second_generation > first_generation);
+}
+
+#[tokio::test]
+async fn rollback_clears_a_terminal_ack_before_the_child_is_reused() {
+    let manager = ThreadStateManager::new();
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    let child_state = manager.thread_state(child_thread_id).await;
+    {
+        let mut state = child_state.lock().await;
+        activate_spine_turn(&mut state, "child-turn", 11);
+        finish_spine_turn(&mut state, "child-turn");
+    }
+    manager
+        .acknowledge_spine_ui_agent_terminal(child_thread_id, 0, "child-turn")
+        .await;
+
+    child_state.lock().await.reset_spine_ui_after_rollback();
+    manager
+        .clear_all_spine_ui_routes_for_thread(child_thread_id)
+        .await;
+    register_test_route(&manager, parent_thread_id, "parent-turn", child_thread_id).await;
+
+    let (states, timed_out) = manager
+        .wait_for_spine_ui_terminal_children(parent_thread_id, "parent-turn", Duration::ZERO)
+        .await;
+    assert_eq!(timed_out, vec![(child_thread_id, states[0].1)]);
+    assert!(states[0].2.is_none());
+}

--- a/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_resource.rs
@@ -57,6 +57,9 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
+const INTERNAL_SPINE_UI_SERVER: &str = "__codex_internal_spine_tree_ui__";
+const INTERNAL_SPINE_UI_RESOURCE_URI: &str = "ui://spine/tree.html";
+const COLLISION_RESOURCE_TEXT: &str = "Resource body from the configured colliding MCP server.";
 const TEST_RESOURCE_URI: &str = "test://codex/resource";
 const TEST_BLOB_RESOURCE_URI: &str = "test://codex/resource.bin";
 const TEST_RESOURCE_BLOB: &str = "YmluYXJ5LXJlc291cmNl";
@@ -125,6 +128,113 @@ async fn mcp_resource_read_returns_resource_contents() -> Result<()> {
         to_response::<McpResourceReadResponse>(read_response)?,
         expected_resource_read_response()
     );
+
+    apps_server_handle.abort();
+    let _ = apps_server_handle.await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn disabled_spine_ui_does_not_claim_a_configured_server_resource() -> Result<()> {
+    let responses_server = responses::start_mock_server().await;
+    let (apps_server_url, _apps_server_calls, apps_server_handle) =
+        start_resource_apps_mcp_server().await?;
+    let extra_config = format!(
+        r#"
+[mcp_servers.{INTERNAL_SPINE_UI_SERVER}]
+url = "{apps_server_url}/api/codex/ps/mcp"
+"#
+    );
+    let (_codex_home, mut mcp) = start_resource_test_app_server_with_extra_config(
+        &apps_server_url,
+        &responses_server.uri(),
+        &extra_config,
+        ResourceTestEnvironment::Auto,
+        SpineUiTestMode::Disabled,
+    )
+    .await?;
+
+    let request_id = mcp
+        .send_mcp_resource_read_request(McpResourceReadParams {
+            thread_id: None,
+            server: INTERNAL_SPINE_UI_SERVER.to_string(),
+            uri: INTERNAL_SPINE_UI_RESOURCE_URI.to_string(),
+        })
+        .await?;
+    let response: McpResourceReadResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??,
+    )?;
+
+    assert_eq!(response.contents.len(), 1);
+    let McpResourceContent::Text {
+        uri,
+        mime_type,
+        text,
+        ..
+    } = &response.contents[0]
+    else {
+        panic!("expected configured MCP text resource")
+    };
+    assert_eq!(uri, INTERNAL_SPINE_UI_RESOURCE_URI);
+    assert_eq!(mime_type.as_deref(), Some("text/plain"));
+    assert_eq!(text, COLLISION_RESOURCE_TEXT);
+
+    apps_server_handle.abort();
+    let _ = apps_server_handle.await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn internal_spine_ui_resource_uri_wins_over_a_configured_name_collision() -> Result<()> {
+    let responses_server = responses::start_mock_server().await;
+    let (apps_server_url, _apps_server_calls, apps_server_handle) =
+        start_resource_apps_mcp_server().await?;
+    let extra_config = format!(
+        r#"
+[mcp_servers.{INTERNAL_SPINE_UI_SERVER}]
+url = "{apps_server_url}/api/codex/ps/mcp"
+"#
+    );
+    let (_codex_home, mut mcp) = start_resource_test_app_server_with_extra_config(
+        &apps_server_url,
+        &responses_server.uri(),
+        &extra_config,
+        ResourceTestEnvironment::Auto,
+        SpineUiTestMode::Enabled,
+    )
+    .await?;
+
+    let request_id = mcp
+        .send_mcp_resource_read_request(McpResourceReadParams {
+            thread_id: None,
+            server: INTERNAL_SPINE_UI_SERVER.to_string(),
+            uri: INTERNAL_SPINE_UI_RESOURCE_URI.to_string(),
+        })
+        .await?;
+    let response: McpResourceReadResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??,
+    )?;
+
+    let McpResourceContent::Text {
+        uri,
+        mime_type,
+        text,
+        ..
+    } = &response.contents[0]
+    else {
+        panic!("expected Spine UI text resource")
+    };
+    assert_eq!(uri, INTERNAL_SPINE_UI_RESOURCE_URI);
+    assert_eq!(mime_type.as_deref(), Some("text/html;profile=mcp-app"));
+    assert!(text.contains("<!doctype html>"));
 
     apps_server_handle.abort();
     let _ = apps_server_handle.await;
@@ -463,6 +573,7 @@ async fn disabled_orchestrator_skills_do_not_expose_skills_namespace() -> Result
 enabled = false
 "#,
         ResourceTestEnvironment::Auto,
+        SpineUiTestMode::Inherited,
     )
     .await?;
 
@@ -668,6 +779,7 @@ async fn start_resource_test_app_server(
         responses_server_uri,
         "",
         environment,
+        SpineUiTestMode::Inherited,
     )
     .await
 }
@@ -677,6 +789,7 @@ async fn start_resource_test_app_server_with_extra_config(
     responses_server_uri: &str,
     extra_config: &str,
     environment: ResourceTestEnvironment,
+    spine_ui_mode: SpineUiTestMode,
 ) -> Result<(TempDir, TestAppServer)> {
     let codex_home = TempDir::new()?;
     std::fs::write(
@@ -722,6 +835,15 @@ stream_max_retries = 0
         // The Local caller explicitly exercises the implicit local executor.
         ResourceTestEnvironment::Local => builder.without_auto_env(),
     };
+    let builder = match spine_ui_mode {
+        SpineUiTestMode::Inherited => builder,
+        SpineUiTestMode::Enabled => {
+            builder.with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
+        }
+        SpineUiTestMode::Disabled => {
+            builder.with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("off"))])
+        }
+    };
     let mut mcp = builder.build().await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     Ok((codex_home, mcp))
@@ -730,6 +852,12 @@ stream_max_retries = 0
 enum ResourceTestEnvironment {
     Auto,
     Local,
+}
+
+enum SpineUiTestMode {
+    Inherited,
+    Enabled,
+    Disabled,
 }
 
 async fn start_resource_apps_mcp_server()
@@ -883,6 +1011,16 @@ impl ServerHandler for ResourceAppsMcpServer {
                     uri: SKILL_REFERENCE_URI.to_string(),
                     mime_type: Some("text/markdown".to_string()),
                     text: SKILL_REFERENCE_CONTENTS.to_string(),
+                    meta: None,
+                },
+            ]));
+        }
+        if uri == INTERNAL_SPINE_UI_RESOURCE_URI {
+            return Ok(ReadResourceResult::new(vec![
+                ResourceContents::TextResourceContents {
+                    uri: INTERNAL_SPINE_UI_RESOURCE_URI.to_string(),
+                    mime_type: Some("text/plain".to_string()),
+                    text: COLLISION_RESOURCE_TEXT.to_string(),
                     meta: None,
                 },
             ]));

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_status.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_status.rs
@@ -12,6 +12,7 @@ use app_test_support::write_mock_responses_config_toml;
 use axum::Router;
 use codex_app_server_protocol::ListMcpServerStatusParams;
 use codex_app_server_protocol::ListMcpServerStatusResponse;
+use codex_app_server_protocol::McpServerStatus;
 use codex_app_server_protocol::McpServerStatusDetail;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadStartParams;
@@ -41,6 +42,15 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
+const INTERNAL_SPINE_UI_SERVER: &str = "__codex_internal_spine_tree_ui__";
+
+fn server_status<'a>(response: &'a ListMcpServerStatusResponse, name: &str) -> &'a McpServerStatus {
+    response
+        .data
+        .iter()
+        .find(|status| status.name == name)
+        .unwrap_or_else(|| panic!("missing MCP server status for {name}"))
+}
 
 #[tokio::test]
 async fn mcp_server_status_list_returns_raw_server_and_tool_names() -> Result<()> {
@@ -70,6 +80,7 @@ url = "{mcp_server_url}/mcp"
     let mut mcp = TestAppServer::builder()
         .with_codex_home(codex_home.path())
         .without_auto_env()
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
         .build()
         .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -90,8 +101,8 @@ url = "{mcp_server_url}/mcp"
     let response: ListMcpServerStatusResponse = to_response(response)?;
 
     assert_eq!(response.next_cursor, None);
-    assert_eq!(response.data.len(), 1);
-    let status = &response.data[0];
+    assert_eq!(response.data.len(), 2);
+    let status = server_status(&response, "some-server");
     assert_eq!(status.name, "some-server");
     assert_eq!(
         status.tools.keys().cloned().collect::<BTreeSet<_>>(),
@@ -112,9 +123,167 @@ url = "{mcp_server_url}/mcp"
         Some("Lookup Server")
     );
 
+    let spine_status = server_status(&response, INTERNAL_SPINE_UI_SERVER);
+    let spine_tool = spine_status
+        .tools
+        .get("spine_tree")
+        .expect("Spine Tree tool");
+    assert_eq!(
+        spine_tool.meta.as_ref().expect("Spine tool metadata")["ui"]["resourceUri"],
+        "ui://spine/tree.html"
+    );
+    assert_eq!(spine_status.resources.len(), 1);
+    assert_eq!(
+        spine_status
+            .resources
+            .iter()
+            .find(|resource| resource.uri == "ui://spine/tree.html")
+            .and_then(|resource| resource.mime_type.as_deref()),
+        Some("text/html;profile=mcp-app")
+    );
+
+    let first_page_id = mcp
+        .send_list_mcp_server_status_request(ListMcpServerStatusParams {
+            cursor: None,
+            limit: Some(1),
+            detail: None,
+            thread_id: None,
+        })
+        .await?;
+    let first_page: ListMcpServerStatusResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(first_page_id)),
+        )
+        .await??,
+    )?;
+    assert_eq!(first_page.next_cursor.as_deref(), Some("1"));
+    assert_eq!(first_page.data[0].name, INTERNAL_SPINE_UI_SERVER);
+
+    let second_page_id = mcp
+        .send_list_mcp_server_status_request(ListMcpServerStatusParams {
+            cursor: first_page.next_cursor,
+            limit: Some(1),
+            detail: None,
+            thread_id: None,
+        })
+        .await?;
+    let second_page: ListMcpServerStatusResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(second_page_id)),
+        )
+        .await??,
+    )?;
+    assert_eq!(second_page.next_cursor, None);
+    assert_eq!(second_page.data[0].name, "some-server");
+
     mcp_server_handle.abort();
     let _ = mcp_server_handle.await;
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_server_status_list_omits_internal_spine_ui_by_default() -> Result<()> {
+    let server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;
+    let codex_home = TempDir::new()?;
+    write_mock_responses_config_toml(
+        codex_home.path(),
+        &server.uri(),
+        &BTreeMap::new(),
+        /*auto_compact_limit*/ 1024,
+        /*requires_openai_auth*/ None,
+        "mock_provider",
+        "compact",
+    )?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", None)])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_list_mcp_server_status_request(ListMcpServerStatusParams {
+            cursor: None,
+            limit: None,
+            detail: None,
+            thread_id: None,
+        })
+        .await?;
+    let response: ListMcpServerStatusResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??,
+    )?;
+
+    assert_eq!(response.data, Vec::new());
+    assert_eq!(response.next_cursor, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_server_status_list_reserves_internal_spine_ui_name() -> Result<()> {
+    let server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;
+    let (mcp_server_url, mcp_server_handle) = start_mcp_server("configured_collision").await?;
+    let codex_home = TempDir::new()?;
+    write_mock_responses_config_toml(
+        codex_home.path(),
+        &server.uri(),
+        &BTreeMap::new(),
+        /*auto_compact_limit*/ 1024,
+        /*requires_openai_auth*/ None,
+        "mock_provider",
+        "compact",
+    )?;
+    let config_path = codex_home.path().join("config.toml");
+    let mut config_toml = std::fs::read_to_string(&config_path)?;
+    config_toml.push_str(&format!(
+        r#"
+[mcp_servers.{INTERNAL_SPINE_UI_SERVER}]
+url = "{mcp_server_url}/mcp"
+"#
+    ));
+    std::fs::write(config_path, config_toml)?;
+
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_list_mcp_server_status_request(ListMcpServerStatusParams {
+            cursor: None,
+            limit: None,
+            detail: None,
+            thread_id: None,
+        })
+        .await?;
+    let response: ListMcpServerStatusResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??,
+    )?;
+
+    assert_eq!(response.data.len(), 1);
+    let status = server_status(&response, INTERNAL_SPINE_UI_SERVER);
+    assert_eq!(
+        status.tools.keys().cloned().collect::<BTreeSet<_>>(),
+        BTreeSet::from(["spine_tree".to_string()])
+    );
+    assert_eq!(status.resources.len(), 1);
+
+    mcp_server_handle.abort();
+    let _ = mcp_server_handle.await;
     Ok(())
 }
 
@@ -138,6 +307,7 @@ async fn mcp_server_status_list_uses_thread_project_local_config() -> Result<()>
 
     let mut mcp = TestAppServer::builder()
         .with_codex_home(codex_home.path())
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
         .build()
         .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -181,7 +351,10 @@ url = "{mcp_server_url}/mcp"
     )
     .await??;
     let threadless_response: ListMcpServerStatusResponse = to_response(threadless_response)?;
-    assert_eq!(threadless_response.data, Vec::new());
+    assert_eq!(threadless_response.data.len(), 1);
+    assert_eq!(threadless_response.data[0].name, INTERNAL_SPINE_UI_SERVER);
+    assert!(threadless_response.data[0].resources.is_empty());
+    assert!(threadless_response.data[0].resource_templates.is_empty());
 
     let thread_request_id = mcp
         .send_list_mcp_server_status_request(ListMcpServerStatusParams {
@@ -199,8 +372,8 @@ url = "{mcp_server_url}/mcp"
     let thread_response: ListMcpServerStatusResponse = to_response(thread_response)?;
 
     assert_eq!(thread_response.next_cursor, None);
-    assert_eq!(thread_response.data.len(), 1);
-    let status = &thread_response.data[0];
+    assert_eq!(thread_response.data.len(), 2);
+    let status = server_status(&thread_response, "project-server");
     assert_eq!(status.name, "project-server");
     assert_eq!(
         status.tools.keys().cloned().collect::<BTreeSet<_>>(),
@@ -346,6 +519,7 @@ url = "{mcp_server_url}/mcp"
     let mut mcp = TestAppServer::builder()
         .with_codex_home(codex_home.path())
         .without_auto_env()
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
         .build()
         .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -366,8 +540,8 @@ url = "{mcp_server_url}/mcp"
     let response: ListMcpServerStatusResponse = to_response(response)?;
 
     assert_eq!(response.next_cursor, None);
-    assert_eq!(response.data.len(), 1);
-    let status = &response.data[0];
+    assert_eq!(response.data.len(), 2);
+    let status = server_status(&response, "some-server");
     assert_eq!(status.name, "some-server");
     assert_eq!(
         status.tools.keys().cloned().collect::<BTreeSet<_>>(),
@@ -415,6 +589,7 @@ url = "{underscore_server_url}/mcp"
     let mut mcp = TestAppServer::builder()
         .with_codex_home(codex_home.path())
         .without_auto_env()
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
         .build()
         .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -435,10 +610,11 @@ url = "{underscore_server_url}/mcp"
     let response: ListMcpServerStatusResponse = to_response(response)?;
 
     assert_eq!(response.next_cursor, None);
-    assert_eq!(response.data.len(), 2);
+    assert_eq!(response.data.len(), 3);
     let status_tools = response
         .data
         .iter()
+        .filter(|status| status.name != INTERNAL_SPINE_UI_SERVER)
         .map(|status| {
             (
                 status.name.as_str(),

--- a/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
@@ -72,6 +72,7 @@ use super::exec_server_test_support::accept_exec_server_environment;
 use super::exec_server_test_support::read_exec_server_json;
 
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
+const INTERNAL_SPINE_UI_SERVER: &str = "__codex_internal_spine_tree_ui__";
 const TEST_SERVER_NAME: &str = "tool_server";
 const TEST_TOOL_NAME: &str = "echo_tool";
 const LARGE_RESPONSE_MESSAGE: &str = "large";
@@ -204,6 +205,133 @@ async fn mcp_server_tool_call_returns_error_for_unknown_thread() -> Result<()> {
         "expected thread-not-found error, got: {error:?}"
     );
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn internal_spine_tree_tool_call_returns_standard_mcp_result() -> Result<()> {
+    let responses_server = responses::start_mock_server().await;
+    let (mcp_server_url, mcp_server_handle) = start_mcp_server().await?;
+    let codex_home = TempDir::new()?;
+    write_mock_responses_config_toml(
+        codex_home.path(),
+        &responses_server.uri(),
+        &BTreeMap::new(),
+        /*auto_compact_limit*/ 1024,
+        /*requires_openai_auth*/ None,
+        "mock_provider",
+        "compact",
+    )?;
+    let config_path = codex_home.path().join("config.toml");
+    let mut config_toml = std::fs::read_to_string(&config_path)?;
+    config_toml.push_str(&format!(
+        r#"
+[mcp_servers.{INTERNAL_SPINE_UI_SERVER}]
+url = "{mcp_server_url}/mcp"
+"#
+    ));
+    std::fs::write(config_path, config_toml)?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let thread_start_id = mcp
+        .send_thread_start_request_with_auto_env(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_start_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_start_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response(thread_start_resp)?;
+
+    let request_id = mcp
+        .send_mcp_server_tool_call_request(McpServerToolCallParams {
+            thread_id: thread.id,
+            server: INTERNAL_SPINE_UI_SERVER.to_string(),
+            tool: "spine_tree".to_string(),
+            arguments: Some(json!({})),
+            meta: None,
+        })
+        .await?;
+    let response: McpServerToolCallResponse = to_response(
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??,
+    )?;
+
+    assert_eq!(response.is_error, Some(true));
+    assert_eq!(response.structured_content, None);
+    assert_eq!(
+        response.content[0].get("text"),
+        Some(&json!("No Spine Tree is active for this thread."))
+    );
+
+    mcp_server_handle.abort();
+    let _ = mcp_server_handle.await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn internal_spine_tree_tool_call_is_disabled_by_soft_off() -> Result<()> {
+    let responses_server = responses::start_mock_server().await;
+    let codex_home = TempDir::new()?;
+    write_mock_responses_config_toml(
+        codex_home.path(),
+        &responses_server.uri(),
+        &BTreeMap::new(),
+        /*auto_compact_limit*/ 1024,
+        /*requires_openai_auth*/ None,
+        "mock_provider",
+        "compact",
+    )?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("off"))])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let thread_start_id = mcp
+        .send_thread_start_request_with_auto_env(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_start_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_start_id)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response(thread_start_resp)?;
+
+    let request_id = mcp
+        .send_mcp_server_tool_call_request(McpServerToolCallParams {
+            thread_id: thread.id,
+            server: INTERNAL_SPINE_UI_SERVER.to_string(),
+            tool: "spine_tree".to_string(),
+            arguments: Some(json!({})),
+            meta: None,
+        })
+        .await?;
+    let error: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert!(
+        error.error.message.contains(INTERNAL_SPINE_UI_SERVER),
+        "expected normal MCP not-found error, got: {error:?}"
+    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -63,6 +63,7 @@ mod selected_capability_stack;
 mod selected_environment;
 mod skills_list;
 mod sleep;
+mod spine_ui_live;
 mod thread_archive;
 mod thread_delete;
 mod thread_fork;

--- a/codex-rs/app-server/tests/suite/v2/spine_ui_live.rs
+++ b/codex-rs/app-server/tests/suite/v2/spine_ui_live.rs
@@ -1,0 +1,352 @@
+use anyhow::Result;
+use app_test_support::TestAppServer;
+use app_test_support::create_mock_responses_server_sequence;
+use app_test_support::to_response;
+use app_test_support::write_mock_responses_config_toml;
+use codex_app_server_protocol::ItemCompletedNotification;
+use codex_app_server_protocol::ItemStartedNotification;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::Thread;
+use codex_app_server_protocol::ThreadItem;
+use codex_app_server_protocol::ThreadReadParams;
+use codex_app_server_protocol::ThreadReadResponse;
+use codex_app_server_protocol::ThreadResumeParams;
+use codex_app_server_protocol::ThreadResumeResponse;
+use codex_app_server_protocol::ThreadStartParams;
+use codex_app_server_protocol::ThreadStartResponse;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::UserInput;
+use core_test_support::responses;
+use core_test_support::skip_if_no_network;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+#[cfg(any(target_os = "macos", windows))]
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(not(any(target_os = "macos", windows)))]
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+const SERVER_NAME: &str = "__codex_internal_spine_tree_ui__";
+const TOOL_NAME: &str = "spine_tree";
+const RESOURCE_URI: &str = "ui://spine/tree.html";
+const ROOT_SUMMARY: &str = "root";
+const BEFORE_RESUME_SUMMARY: &str = "before cold resume";
+const AFTER_RESUME_SUMMARY: &str = "after cold resume";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spine_ui_is_live_only_and_rebuilds_core_tree_after_cold_resume() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = create_mock_responses_server_sequence(vec![
+        responses::sse(vec![
+            responses::ev_response_created("spine-open"),
+            responses::ev_function_call_with_namespace(
+                "spine-open",
+                "spine",
+                "open",
+                &format!(r#"{{"summary":"{BEFORE_RESUME_SUMMARY}"}}"#),
+            ),
+            responses::ev_completed("spine-open"),
+        ]),
+        responses::sse(vec![
+            responses::ev_response_created("spine-done"),
+            responses::ev_assistant_message("spine-message", "done"),
+            responses::ev_completed("spine-done"),
+        ]),
+        responses::sse(vec![
+            responses::ev_response_created("spine-resumed-open"),
+            responses::ev_function_call_with_namespace(
+                "spine-resumed-open",
+                "spine",
+                "open",
+                &format!(r#"{{"summary":"{AFTER_RESUME_SUMMARY}"}}"#),
+            ),
+            responses::ev_completed("spine-resumed-open"),
+        ]),
+        responses::sse(vec![
+            responses::ev_response_created("spine-resumed-done"),
+            responses::ev_assistant_message("spine-resumed-message", "done after resume"),
+            responses::ev_completed("spine-resumed-done"),
+        ]),
+    ])
+    .await;
+    let codex_home = TempDir::new()?;
+    write_mock_responses_config_toml(
+        codex_home.path(),
+        &server.uri(),
+        &BTreeMap::new(),
+        /*auto_compact_limit*/ 100_000,
+        /*requires_openai_auth*/ None,
+        "mock_provider",
+        "compact",
+    )?;
+
+    let mut app = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, app.initialize()).await??;
+
+    let thread_request = app
+        .send_thread_start_request_with_auto_env(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_response_message(RequestId::Integer(thread_request)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response(thread_response)?;
+
+    let turn_request = app
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "open a Spine task".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let turn_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_response_message(RequestId::Integer(turn_request)),
+    )
+    .await??;
+    let TurnStartResponse { turn } = to_response(turn_response)?;
+
+    let started = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_matching_notification("live Spine item/started", |notification| {
+            notification.method == "item/started"
+                && notification.params.as_ref().is_some_and(|params| {
+                    serde_json::from_value::<ItemStartedNotification>(params.clone())
+                        .is_ok_and(|notification| is_internal_item(&notification.item))
+                })
+        }),
+    )
+    .await??;
+    let started: ItemStartedNotification =
+        serde_json::from_value(started.params.expect("item/started params"))?;
+    assert_eq!(started.thread_id, thread.id);
+    assert_eq!(started.turn_id, turn.id);
+
+    let completed = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_matching_notification("live Spine item/completed", |notification| {
+            notification.method == "item/completed"
+                && notification.params.as_ref().is_some_and(|params| {
+                    serde_json::from_value::<ItemCompletedNotification>(params.clone())
+                        .is_ok_and(|notification| is_internal_item(&notification.item))
+                })
+        }),
+    )
+    .await??;
+    let completed: ItemCompletedNotification =
+        serde_json::from_value(completed.params.expect("item/completed params"))?;
+    assert_eq!(completed.thread_id, thread.id);
+    assert_eq!(completed.turn_id, turn.id);
+
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+
+    let loaded = read_thread(&mut app, &thread.id).await?;
+    assert_no_internal_items(&loaded);
+    let rollout_path = loaded.path.as_ref().expect("materialized rollout path");
+    let rollout = std::fs::read_to_string(rollout_path)?;
+    for marker in [SERVER_NAME, "spine-ui-", RESOURCE_URI] {
+        assert!(
+            !rollout.contains(marker),
+            "live-only Spine item leaked into rollout via marker {marker}"
+        );
+    }
+
+    drop(app);
+
+    let mut app = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .with_env_overrides(&[("CODEX_SPINE_APP_UI", Some("1"))])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, app.initialize()).await??;
+
+    let reloaded = read_thread(&mut app, &thread.id).await?;
+    assert_no_internal_items(&reloaded);
+
+    let resume_request = app
+        .send_thread_resume_request(ThreadResumeParams {
+            thread_id: thread.id,
+            ..Default::default()
+        })
+        .await?;
+    let resume_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_response_message(RequestId::Integer(resume_request)),
+    )
+    .await??;
+    let ThreadResumeResponse {
+        thread: resumed, ..
+    } = to_response(resume_response)?;
+    assert_no_internal_items(&resumed);
+
+    let resumed_turn_request = app
+        .send_turn_start_request(TurnStartParams {
+            thread_id: resumed.id.clone(),
+            input: vec![UserInput::Text {
+                text: "open another Spine task after cold resume".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let resumed_turn_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_response_message(RequestId::Integer(resumed_turn_request)),
+    )
+    .await??;
+    let TurnStartResponse { turn: resumed_turn } = to_response(resumed_turn_response)?;
+
+    let rebuilt = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_matching_notification(
+            "resumed live Spine item with rebuilt Core nodes",
+            |notification| {
+                notification.method == "item/started"
+                    && notification.params.as_ref().is_some_and(|params| {
+                        serde_json::from_value::<ItemStartedNotification>(params.clone()).is_ok_and(
+                            |notification| {
+                                snapshot_node_summaries(&notification.item).is_some_and(
+                                    |summaries| {
+                                        summaries.contains(BEFORE_RESUME_SUMMARY)
+                                            && summaries.contains(AFTER_RESUME_SUMMARY)
+                                    },
+                                )
+                            },
+                        )
+                    })
+            },
+        ),
+    )
+    .await??;
+    let rebuilt: ItemStartedNotification =
+        serde_json::from_value(rebuilt.params.expect("item/started params"))?;
+    assert_eq!(rebuilt.thread_id, resumed.id);
+    assert_eq!(rebuilt.turn_id, resumed_turn.id);
+    assert_eq!(
+        snapshot_node_summaries(&rebuilt.item),
+        Some(BTreeSet::from([
+            ROOT_SUMMARY.to_string(),
+            BEFORE_RESUME_SUMMARY.to_string(),
+            AFTER_RESUME_SUMMARY.to_string(),
+        ]))
+    );
+    let structured_content =
+        internal_structured_content(&rebuilt.item).expect("internal Spine structured content");
+    assert_eq!(
+        structured_content.get("agentSubtrees"),
+        Some(&serde_json::json!([]))
+    );
+
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_matching_notification(
+            "resumed live Spine item/completed",
+            |notification| {
+                notification.method == "item/completed"
+                    && notification.params.as_ref().is_some_and(|params| {
+                        serde_json::from_value::<ItemCompletedNotification>(params.clone())
+                            .is_ok_and(|notification| {
+                                notification.turn_id == resumed_turn.id
+                                    && is_internal_item(&notification.item)
+                            })
+                    })
+            },
+        ),
+    )
+    .await??;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+
+    let after_resumed_turn = read_thread(&mut app, &resumed.id).await?;
+    assert_no_internal_items(&after_resumed_turn);
+
+    Ok(())
+}
+
+async fn read_thread(app: &mut TestAppServer, thread_id: &str) -> Result<Thread> {
+    let request = app
+        .send_thread_read_request(ThreadReadParams {
+            thread_id: thread_id.to_string(),
+            include_turns: true,
+        })
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app.read_stream_until_response_message(RequestId::Integer(request)),
+    )
+    .await??;
+    let ThreadReadResponse { thread } = to_response(response)?;
+    Ok(thread)
+}
+
+fn assert_no_internal_items(thread: &Thread) {
+    assert!(
+        thread
+            .turns
+            .iter()
+            .flat_map(|turn| &turn.items)
+            .all(|item| !is_internal_item(item)),
+        "thread history restored a live-only Spine item"
+    );
+}
+
+fn is_internal_item(item: &ThreadItem) -> bool {
+    matches!(
+        item,
+        ThreadItem::McpToolCall {
+            id,
+            server,
+            tool,
+            mcp_app_resource_uri: Some(resource_uri),
+            ..
+        } if id.starts_with("spine-ui-")
+            && server == SERVER_NAME
+            && tool == TOOL_NAME
+            && resource_uri == RESOURCE_URI
+    )
+}
+
+fn internal_structured_content(item: &ThreadItem) -> Option<&serde_json::Value> {
+    let ThreadItem::McpToolCall {
+        result: Some(result),
+        ..
+    } = item
+    else {
+        return None;
+    };
+    result.structured_content.as_ref()
+}
+
+fn snapshot_node_summaries(item: &ThreadItem) -> Option<BTreeSet<String>> {
+    Some(
+        internal_structured_content(item)?
+            .pointer("/snapshot/nodes")?
+            .as_array()?
+            .iter()
+            .filter_map(|node| node.get("summary")?.as_str().map(str::to_string))
+            .collect(),
+    )
+}

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2129,16 +2129,18 @@ impl Session {
     /// Delivers experimental spawn progress to live clients without appending it
     /// to the parent rollout.  The completed typed receipt is the sole durable
     /// source for the eventual Spine transition.
-    pub(crate) async fn emit_spine_spawn_progress(
+    pub(crate) fn emit_spine_spawn_progress(
         &self,
         turn_context: &TurnContext,
         progress: codex_protocol::protocol::SpineSpawnProgressEvent,
     ) {
-        self.deliver_event_raw(Event {
+        let event = Event {
             id: turn_context.sub_id.clone(),
             msg: EventMsg::SpineSpawnProgress(progress),
-        })
-        .await;
+        };
+        if let Err(error) = self.tx_event.try_send(event) {
+            debug!("dropping event because channel is closed: {error}");
+        }
     }
 
     async fn publish_spinetree_memory_projection(&self) {

--- a/codex-rs/core/src/spine/spawn.rs
+++ b/codex-rs/core/src/spine/spawn.rs
@@ -28,6 +28,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Display;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::time::Duration;
@@ -548,18 +549,16 @@ async fn execute_batch_transaction(
     }
     let progress_statuses = Arc::new(tokio::sync::Mutex::new(progress_statuses));
     for call_ordinal in 0..progress_calls.len() {
-        session
-            .emit_spine_spawn_progress(
-                turn.as_ref(),
-                batch_progress_event(
-                    progress_calls.as_ref(),
-                    call_ordinal,
-                    progress_thread_ids.as_ref(),
-                    progress_paths.as_ref(),
-                    &progress_statuses.lock().await,
-                ),
-            )
-            .await;
+        session.emit_spine_spawn_progress(
+            turn.as_ref(),
+            batch_progress_event(
+                progress_calls.as_ref(),
+                call_ordinal,
+                progress_thread_ids.as_ref(),
+                progress_paths.as_ref(),
+                &progress_statuses.lock().await,
+            ),
+        );
     }
     let waits = live.iter().map(|(ordinal, thread_id, _)| {
         let control = session.services.agent_control.clone();
@@ -573,23 +572,41 @@ async fn execute_batch_transaction(
         let call_ordinal = flat_tasks[ordinal].0;
         let thread_id = *thread_id;
         async move {
-            let status = wait_for_terminal(&control, thread_id).await;
+            let mut emit_status = |status: AgentStatus| {
+                let session = session.clone();
+                let turn = turn.clone();
+                let progress_calls = progress_calls.clone();
+                let progress_thread_ids = progress_thread_ids.clone();
+                let progress_paths = progress_paths.clone();
+                let progress_statuses = progress_statuses.clone();
+                async move {
+                    let mut statuses = progress_statuses.lock().await;
+                    if statuses[ordinal] == status {
+                        return;
+                    }
+                    statuses[ordinal] = status;
+                    let event = batch_progress_event(
+                        progress_calls.as_ref(),
+                        call_ordinal,
+                        progress_thread_ids.as_ref(),
+                        progress_paths.as_ref(),
+                        &statuses,
+                    );
+                    session.emit_spine_spawn_progress(turn.as_ref(), event);
+                }
+            };
+            let status = match control.subscribe_status(thread_id).await {
+                Ok(status_rx) => {
+                    match wait_for_terminal_status(status_rx, &mut emit_status).await {
+                        Some(status) => status,
+                        None => control.get_status(thread_id).await,
+                    }
+                }
+                Err(_) => control.get_status(thread_id).await,
+            };
             let failure_record = control.take_spawn_failure_record(thread_id).await;
             let result = result_from_status(ordinal, thread_id, status, failure_record);
-            let event = {
-                let mut statuses = progress_statuses.lock().await;
-                statuses[ordinal] = result_status(&result);
-                batch_progress_event(
-                    progress_calls.as_ref(),
-                    call_ordinal,
-                    progress_thread_ids.as_ref(),
-                    progress_paths.as_ref(),
-                    &statuses,
-                )
-            };
-            session
-                .emit_spine_spawn_progress(turn.as_ref(), event)
-                .await;
+            emit_status(result_status(&result)).await;
             (ordinal, result)
         }
     });
@@ -700,9 +717,7 @@ async fn execute_batch_transaction(
                 .collect::<Vec<_>>()
         };
         for event in events {
-            session
-                .emit_spine_spawn_progress(turn.as_ref(), event)
-                .await;
+            session.emit_spine_spawn_progress(turn.as_ref(), event);
         }
     }
 
@@ -958,7 +973,7 @@ fn classify_start_results<E: Display>(
 fn transaction_task_name(call_id: &str, ordinal: usize) -> String {
     let fragment = call_id
         .chars()
-        .filter(|character| character.is_ascii_alphanumeric())
+        .filter(char::is_ascii_alphanumeric)
         .map(|character| character.to_ascii_lowercase())
         .take(20)
         .collect::<String>();
@@ -1011,20 +1026,22 @@ fn task_envelope(task: &SpawnTask, call_tasks: &[SpawnTask]) -> String {
     )
 }
 
-async fn wait_for_terminal(
-    control: &crate::agent::AgentControl,
-    thread_id: ThreadId,
-) -> AgentStatus {
-    let Ok(mut status_rx) = control.subscribe_status(thread_id).await else {
-        return control.get_status(thread_id).await;
-    };
+async fn wait_for_terminal_status<F, Fut>(
+    mut status_rx: tokio::sync::watch::Receiver<AgentStatus>,
+    mut on_progress: F,
+) -> Option<AgentStatus>
+where
+    F: FnMut(AgentStatus) -> Fut,
+    Fut: Future<Output = ()>,
+{
     loop {
         let status = status_rx.borrow_and_update().clone();
         if is_spawn_terminal(&status) {
-            return status;
+            return Some(status);
         }
+        on_progress(status).await;
         if status_rx.changed().await.is_err() {
-            return control.get_status(thread_id).await;
+            return None;
         }
     }
 }

--- a/codex-rs/core/src/spine/spawn_tests.rs
+++ b/codex-rs/core/src/spine/spawn_tests.rs
@@ -262,6 +262,63 @@ fn initial_progress_normalizes_fast_terminal_statuses() {
     ));
 }
 
+#[tokio::test]
+async fn terminal_status_watch_reports_running_before_terminal() {
+    let (status_tx, status_rx) = tokio::sync::watch::channel(AgentStatus::PendingInit);
+    let (running_tx, running_rx) = tokio::sync::oneshot::channel();
+    let waiter = tokio::spawn(async move {
+        let mut running_tx = Some(running_tx);
+        wait_for_terminal_status(status_rx, move |status| {
+            let running_tx = (status == AgentStatus::Running)
+                .then(|| running_tx.take())
+                .flatten();
+            async move {
+                if let Some(running_tx) = running_tx {
+                    let _ = running_tx.send(());
+                }
+            }
+        })
+        .await
+    });
+
+    status_tx
+        .send(AgentStatus::Running)
+        .expect("status watcher should still be active");
+    tokio::time::timeout(Duration::from_secs(1), running_rx)
+        .await
+        .expect("Running progress was not reported")
+        .expect("Running progress observer was dropped");
+    status_tx
+        .send(AgentStatus::Completed(Some("memory".to_string())))
+        .expect("status watcher should still be active");
+
+    assert_eq!(
+        waiter.await.expect("status watcher task should not panic"),
+        Some(AgentStatus::Completed(Some("memory".to_string())))
+    );
+}
+
+#[tokio::test]
+async fn terminal_status_watch_does_not_invent_running_for_fast_terminal() {
+    let (_status_tx, status_rx) =
+        tokio::sync::watch::channel(AgentStatus::Completed(Some("memory".to_string())));
+    let mut observed = Vec::new();
+
+    let terminal = wait_for_terminal_status(status_rx, |status| {
+        observed.push(status);
+        std::future::ready(())
+    })
+    .await;
+
+    assert_eq!(
+        (terminal, observed),
+        (
+            Some(AgentStatus::Completed(Some("memory".to_string()))),
+            Vec::new()
+        )
+    );
+}
+
 #[test]
 fn terminal_status_matrix_produces_one_total_ordered_receipt() {
     let tasks = (0..4)

--- a/codex-rs/core/tests/suite/spine_spawn.rs
+++ b/codex-rs/core/tests/suite/spine_spawn.rs
@@ -705,7 +705,117 @@ async fn failed_child_salvage_preserves_memory_and_cache_key() -> Result<()> {
         salvage_input.last().and_then(|item| item["role"].as_str()),
         Some("developer")
     );
+    Ok(())
+}
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn spawn_progress_reports_running_without_child_spine_nodes() -> Result<()> {
+    let server = start_mock_server().await;
+    mount_sse_once_match(
+        &server,
+        is_parent_spawn_request,
+        sse(vec![
+            ev_response_created("running-progress-parent-spawn"),
+            ev_function_call_with_namespace(
+                SPAWN_CALL_ID,
+                SPAWN_NAMESPACE,
+                SPAWN_TOOL,
+                &spawn_args("running-progress-first", "running-progress-second"),
+            ),
+            ev_completed("running-progress-parent-spawn"),
+        ]),
+    )
+    .await;
+    mount_response_once_match(
+        &server,
+        |request: &wiremock::Request| child_task_marker(request, "running-progress-first"),
+        sse_response(sse(vec![
+            ev_response_created("running-progress-first-response"),
+            ev_assistant_message("running-progress-first-message", "first memory"),
+            ev_completed("running-progress-first-response"),
+        ]))
+        .set_delay(Duration::from_millis(300)),
+    )
+    .await;
+    mount_response_once_match(
+        &server,
+        |request: &wiremock::Request| child_task_marker(request, "running-progress-second"),
+        sse_response(sse(vec![
+            ev_response_created("running-progress-second-response"),
+            ev_assistant_message("running-progress-second-message", "second memory"),
+            ev_completed("running-progress-second-response"),
+        ]))
+        .set_delay(Duration::from_millis(300)),
+    )
+    .await;
+    mount_sse_once_match(
+        &server,
+        |request: &wiremock::Request| {
+            body_contains(request, "first memory")
+                && body_contains(request, "second memory")
+                && !body_contains(request, "You are one branch of a spine.spawn fission")
+        },
+        sse(vec![
+            ev_response_created("running-progress-parent-followup"),
+            ev_assistant_message("running-progress-parent-message", "parent done"),
+            ev_completed("running-progress-parent-followup"),
+        ]),
+    )
+    .await;
+    let test = spine_builder().build(&server).await?;
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: FIRST_PARENT_PROMPT.to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+
+    let mut phases = [0_u8; 2];
+    let mut saw_running = [false; 2];
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(10), test.codex.next_event())
+            .await
+            .context("timed out waiting for spawn progress")??;
+        match event.msg {
+            EventMsg::SpineSpawnProgress(progress) if progress.call_id == SPAWN_CALL_ID => {
+                for task in progress.tasks {
+                    let ordinal = usize::try_from(task.ordinal).context("task ordinal overflow")?;
+                    let phase = match task.status {
+                        AgentStatus::PendingInit => 0,
+                        AgentStatus::Running => {
+                            saw_running[ordinal] = true;
+                            1
+                        }
+                        _ => {
+                            assert!(
+                                saw_running[ordinal],
+                                "task {ordinal} reached {status:?} without reporting Running",
+                                status = task.status
+                            );
+                            2
+                        }
+                    };
+                    assert!(
+                        phase >= phases[ordinal],
+                        "task {ordinal} progress regressed from phase {previous} to {phase}",
+                        previous = phases[ordinal]
+                    );
+                    phases[ordinal] = phase;
+                }
+            }
+            EventMsg::TurnComplete(_) => break,
+            _ => {}
+        }
+    }
+
+    assert_eq!((phases, saw_running), ([2, 2], [true, true]));
     Ok(())
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/app_server.rs
+++ b/codex-rs/tui/src/chatwidget/tests/app_server.rs
@@ -62,6 +62,24 @@ fn configured_thread_session(thread_id: ThreadId) -> crate::session_state::Threa
     }
 }
 
+fn internal_spine_ui_item(
+    status: codex_app_server_protocol::McpToolCallStatus,
+) -> AppServerThreadItem {
+    AppServerThreadItem::McpToolCall {
+        id: "spine-ui-turn-1".to_string(),
+        server: "__codex_internal_spine_tree_ui__".to_string(),
+        tool: "spine_tree".to_string(),
+        status,
+        arguments: json!({}),
+        app_context: None,
+        mcp_app_resource_uri: Some("ui://spine/tree.html".to_string()),
+        plugin_id: None,
+        result: None,
+        error: None,
+        duration_ms: None,
+    }
+}
+
 fn start_safety_buffering_test_turn(
     chat: &mut ChatWidget,
     op_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Op>,
@@ -469,6 +487,34 @@ async fn collab_spawn_end_shows_requested_model_and_effort() {
         rendered.contains("Spawned Robie [explorer] (gpt-5 high)"),
         "expected spawn line to include agent metadata and requested model, got {rendered:?}"
     );
+}
+
+#[tokio::test]
+async fn live_internal_spine_ui_items_are_not_rendered() {
+    let (mut chat, mut rx, _ops) = make_chatwidget_manual(/*model_override*/ None).await;
+    let _ = drain_insert_history(&mut rx);
+
+    chat.handle_server_notification(
+        ServerNotification::ItemStarted(ItemStartedNotification {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            started_at_ms: 0,
+            item: internal_spine_ui_item(codex_app_server_protocol::McpToolCallStatus::InProgress),
+        }),
+        /*replay_kind*/ None,
+    );
+    chat.handle_server_notification(
+        ServerNotification::ItemCompleted(ItemCompletedNotification {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            completed_at_ms: 0,
+            item: internal_spine_ui_item(codex_app_server_protocol::McpToolCallStatus::Completed),
+        }),
+        /*replay_kind*/ None,
+    );
+
+    assert!(drain_insert_history(&mut rx).is_empty());
+    assert!(chat.transcript.active_cell.is_none());
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
@@ -4,6 +4,7 @@
 //! events as transcript cells.
 
 use super::*;
+use crate::internal_spine_ui;
 use codex_utils_path_uri::LegacyAppPathString;
 
 impl ChatWidget {
@@ -53,6 +54,9 @@ impl ChatWidget {
     }
 
     pub(super) fn on_mcp_tool_call_started(&mut self, item: ThreadItem) {
+        if internal_spine_ui::is_item(&item) {
+            return;
+        }
         let item2 = item.clone();
         self.defer_or_handle(
             |q| q.push_item_started(item),
@@ -61,6 +65,9 @@ impl ChatWidget {
     }
 
     pub(super) fn on_mcp_tool_call_completed(&mut self, item: ThreadItem) {
+        if internal_spine_ui::is_item(&item) {
+            return;
+        }
         let item2 = item.clone();
         self.defer_or_handle(
             |q| q.push_item_completed(item),

--- a/codex-rs/tui/src/history_cell/mcp.rs
+++ b/codex-rs/tui/src/history_cell/mcp.rs
@@ -1,6 +1,7 @@
 //! MCP tool-call, inventory, and output history cells.
 
 use super::*;
+use crate::internal_spine_ui;
 
 #[derive(Debug)]
 struct CompletedMcpToolCallWithImageOutput {
@@ -532,7 +533,10 @@ pub(crate) fn new_mcp_tools_output_from_statuses(
         "".into(),
     ];
 
-    let mut statuses = statuses.iter().collect::<Vec<_>>();
+    let mut statuses = statuses
+        .iter()
+        .filter(|status| !internal_spine_ui::is_server_status(status))
+        .collect::<Vec<_>>();
     statuses.sort_by(|a, b| a.name.cmp(&b.name));
 
     let has_any_tools = statuses.iter().any(|status| !status.tools.is_empty());

--- a/codex-rs/tui/src/history_cell/tests.rs
+++ b/codex-rs/tui/src/history_cell/tests.rs
@@ -901,26 +901,50 @@ async fn mcp_tools_output_lists_tools_for_hyphenated_server_names() {
 
 #[test]
 fn mcp_tools_output_from_statuses_renders_status_only_servers() {
-    let statuses = vec![McpServerStatus {
-        name: "plugin_docs".to_string(),
-        server_info: None,
-        tools: HashMap::from([(
-            "lookup".to_string(),
-            Tool {
-                description: None,
-                name: "lookup".to_string(),
-                title: None,
-                input_schema: serde_json::json!({"type": "object", "properties": {}}),
-                output_schema: None,
-                annotations: None,
-                icons: None,
-                meta: None,
-            },
-        )]),
-        resources: Vec::new(),
-        resource_templates: Vec::new(),
-        auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
-    }];
+    let statuses = vec![
+        McpServerStatus {
+            name: "plugin_docs".to_string(),
+            server_info: None,
+            tools: HashMap::from([(
+                "lookup".to_string(),
+                Tool {
+                    description: None,
+                    name: "lookup".to_string(),
+                    title: None,
+                    input_schema: serde_json::json!({"type": "object", "properties": {}}),
+                    output_schema: None,
+                    annotations: None,
+                    icons: None,
+                    meta: None,
+                },
+            )]),
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
+        },
+        McpServerStatus {
+            name: "__codex_internal_spine_tree_ui__".to_string(),
+            server_info: None,
+            tools: HashMap::from([(
+                "spine_tree".to_string(),
+                Tool {
+                    description: None,
+                    name: "spine_tree".to_string(),
+                    title: None,
+                    input_schema: serde_json::json!({"type": "object"}),
+                    output_schema: None,
+                    annotations: None,
+                    icons: None,
+                    meta: Some(serde_json::json!({
+                        "ui": {"resourceUri": "ui://spine/tree.html"}
+                    })),
+                },
+            )]),
+            resources: Vec::new(),
+            resource_templates: Vec::new(),
+            auth_status: codex_app_server_protocol::McpAuthStatus::Unsupported,
+        },
+    ];
 
     let cell =
         new_mcp_tools_output_from_statuses(&statuses, McpServerStatusDetail::ToolsAndAuthOnly);

--- a/codex-rs/tui/src/internal_spine_ui.rs
+++ b/codex-rs/tui/src/internal_spine_ui.rs
@@ -1,0 +1,35 @@
+use codex_app_server_protocol::McpServerStatus;
+use codex_app_server_protocol::ThreadItem;
+
+const ITEM_ID_PREFIX: &str = "spine-ui-";
+const SERVER_NAME: &str = "__codex_internal_spine_tree_ui__";
+const TOOL_NAME: &str = "spine_tree";
+const RESOURCE_URI: &str = "ui://spine/tree.html";
+
+pub(crate) fn is_item(item: &ThreadItem) -> bool {
+    let ThreadItem::McpToolCall {
+        id,
+        server,
+        tool,
+        mcp_app_resource_uri,
+        ..
+    } = item
+    else {
+        return false;
+    };
+    id.starts_with(ITEM_ID_PREFIX)
+        && server == SERVER_NAME
+        && tool == TOOL_NAME
+        && mcp_app_resource_uri.as_deref() == Some(RESOURCE_URI)
+}
+
+pub(crate) fn is_server_status(status: &McpServerStatus) -> bool {
+    status.name == SERVER_NAME
+        && status.tools.get(TOOL_NAME).is_some_and(|tool| {
+            tool.meta
+                .as_ref()
+                .and_then(|meta| meta.pointer("/ui/resourceUri"))
+                .and_then(serde_json::Value::as_str)
+                == Some(RESOURCE_URI)
+        })
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -129,6 +129,7 @@ mod hooks_rpc;
 mod ide_context;
 pub(crate) mod insert_history;
 pub use insert_history::insert_history_lines;
+mod internal_spine_ui;
 mod key_hint;
 mod keymap;
 mod keymap_setup;

--- a/codex-rs/tui/src/multi_agents.rs
+++ b/codex-rs/tui/src/multi_agents.rs
@@ -5,6 +5,7 @@
 //! which thread becomes active or when a thread closes, stays in [`crate::app::App`].
 
 use crate::history_cell::PlainHistoryCell;
+use crate::internal_spine_ui;
 use crate::render::line_utils::prefix_lines;
 use crate::style::muted_text_style;
 use crate::text_formatting::truncate_text;
@@ -274,6 +275,10 @@ fn agent_activity_summary(
     item: &ThreadItem,
     path_display: AgentActivityPathDisplay,
 ) -> Option<String> {
+    if internal_spine_ui::is_item(item) {
+        return None;
+    }
+
     let summary = match item {
         ThreadItem::AgentMessage { text, .. } | ThreadItem::Plan { text, .. } => text,
         ThreadItem::Reasoning { summary, .. } => summary.last()?,
@@ -1227,6 +1232,47 @@ mod tests {
         let rendered = preview.lines(80)[0].to_string();
         assert_eq!(rendered, "Started sub-agent");
         assert!(!rendered.contains("/root/worker"));
+    }
+
+    #[test]
+    fn activity_preview_hides_internal_spine_ui_and_keeps_regular_mcp() {
+        let internal_spine = ThreadItem::McpToolCall {
+            id: "spine-ui-turn-1".to_string(),
+            server: "__codex_internal_spine_tree_ui__".to_string(),
+            tool: "spine_tree".to_string(),
+            status: codex_app_server_protocol::McpToolCallStatus::Completed,
+            arguments: serde_json::Value::Null,
+            app_context: None,
+            mcp_app_resource_uri: Some("ui://spine/tree.html".to_string()),
+            plugin_id: None,
+            result: None,
+            error: None,
+            duration_ms: None,
+        };
+        let regular_mcp = ThreadItem::McpToolCall {
+            id: "call-regular".to_string(),
+            server: "filesystem".to_string(),
+            tool: "read_file".to_string(),
+            status: codex_app_server_protocol::McpToolCallStatus::Completed,
+            arguments: serde_json::Value::Null,
+            app_context: None,
+            mcp_app_resource_uri: None,
+            plugin_id: None,
+            result: None,
+            error: None,
+            duration_ms: None,
+        };
+
+        let preview = AgentActivityPreview::from_items(
+            [&internal_spine, &regular_mcp].into_iter(),
+            AgentActivityPathDisplay::Hide,
+        );
+
+        assert_eq!(preview.activity, vec!["MCP filesystem/read_file"]);
+        assert_snapshot!(
+            "activity_preview_filters_internal_spine_ui_item",
+            preview.lines(80)[0].to_string()
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/snapshots/codex_tui__multi_agents__tests__activity_preview_filters_internal_spine_ui_item.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__multi_agents__tests__activity_preview_filters_internal_spine_ui_item.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/multi_agents.rs
+expression: "preview.lines(80)[0].to_string()"
+---
+MCP filesystem/read_file


### PR DESCRIPTION
## Summary

This PR adds a strict opt-in, read-only live Spine task-tree view for Codex App.

- Each Spine-active turn gets one transient MCP App card.
- Updates in the same turn replace the same item through a monotonic revision.
- A later Spine-active turn gets a new card containing the complete tree accumulated by the active listener.
- Agent subtrees show child-owned nodes and nested agents without repeating the parent fork baseline.
- The UI projection is not written to rollout history or model context.

## Implementation

- Adds an app-server-owned Spine UI runtime with generation-aware child routes, revision coalescing, terminal acknowledgements, timeout handling, rollback cleanup, and late-terminal refresh.
- Serves a self-contained `ui://spine/tree.html` MCP App resource with compact, validated payloads.
- Emits live Agent `Running` progress for agents that do not create Spine nodes.
- Filters the exact internal MCP carrier from TUI live items, Agent activity, and `/mcp` inventory while preserving ordinary MCP items.

## Behavior

- Disabled by default; enable with `CODEX_SPINE_APP_UI=1`, `true`, or `on`.
- Same-turn updates are live-only and do not create history items.
- Cold resume can rebuild parent Core Spine nodes from ordinary rollout; those nodes can appear in a later new card.
- Old live cards, Agent live subtrees, routes, and live status are intentionally not restored after reload or restart.
- The TUI keeps its native Spine view and does not display the Desktop-only internal carrier.

## Validation

- App-server Spine UI: 40/40 passed.
- Internal Spine MCP: 5/5 passed.
- Runtime/manager: 21/21 passed.
- Cold-resume E2E passed: live card, no internal rollout/history item, and rebuilt parent Core nodes in the next card.
- Core and TUI targeted regressions passed: 3/3 and 2/2.
- Formatting, checks, fix, build, and `git diff --check` passed with 8 jobs.
- Full app-server: 948 passed, 10 failures, 8 skipped. Full TUI: 3173 passed, 6 failures, 10 skipped. Every failure was reproduced on the latest `main` baseline and is outside this change.

## Known limitation

Each new card contains the complete accumulated tree, so keeping many cards open can increase frontend memory and network usage with session length. The cards add no rollout or on-disk growth.