### PR TITLE
feat: add SpineCodex Desktop launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ npm install -g @spinejit/spine-codex@latest
 spine-codex
 ```
 
+### Codex Desktop
+
+To use SpineCodex with the official Codex Desktop app, first quit Codex Desktop,
+then download the launcher for your platform:
+
+- **Windows:** Keep [`start-spinecodex-desktop.cmd`](./scripts/codex-desktop/start-spinecodex-desktop.cmd)
+  and [`start-spinecodex-desktop.ps1`](./scripts/codex-desktop/start-spinecodex-desktop.ps1)
+  in the same folder, then run the `.cmd` file.
+- **macOS:** Run [`start-spinecodex-desktop.command`](./scripts/codex-desktop/start-spinecodex-desktop.command).
+  If needed, make it executable with `chmod +x start-spinecodex-desktop.command`.
+
+The launchers use the native SpineCodex backend installed by npm and enable the
+Spine tree UI automatically.
+
 ## Experimental features
 
 | Feature                                                       | Purpose                                                                                                                                                                     |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,15 @@ npm install -g @spinejit/spine-codex@latest
 spine-codex
 ```
 
+### Codex Desktop
+
+如需在官方 Codex Desktop 中使用 SpineCodex，请先完全退出 Codex Desktop，再下载对应平台的启动器：
+
+- **Windows：**将 [`start-spinecodex-desktop.cmd`](./scripts/codex-desktop/start-spinecodex-desktop.cmd) 和 [`start-spinecodex-desktop.ps1`](./scripts/codex-desktop/start-spinecodex-desktop.ps1) 放在同一目录，然后运行 `.cmd` 文件。
+- **macOS：**运行 [`start-spinecodex-desktop.command`](./scripts/codex-desktop/start-spinecodex-desktop.command)。如有需要，先执行 `chmod +x start-spinecodex-desktop.command` 添加执行权限。
+
+启动器会使用 npm 安装的原生 SpineCodex 后端，并自动启用 Spine 树形界面。
+
 ## 实验功能
 
 | 功能                                                   | 用途                                                                                                       |

--- a/scripts/codex-desktop/start-spinecodex-desktop.cmd
+++ b/scripts/codex-desktop/start-spinecodex-desktop.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal EnableExtensions
+
+set "LAUNCHER=%~dp0start-spinecodex-desktop.ps1"
+if not exist "%LAUNCHER%" (
+    echo Missing launcher script: "%LAUNCHER%"
+    pause
+    exit /b 1
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%LAUNCHER%"
+exit /b %ERRORLEVEL%

--- a/scripts/codex-desktop/start-spinecodex-desktop.command
+++ b/scripts/codex-desktop/start-spinecodex-desktop.command
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+show_error() {
+    local message="$1"
+    local exit_code="${2:-1}"
+    trap - ERR
+
+    if command -v osascript >/dev/null 2>&1; then
+        if ! osascript \
+            -e 'on run argv' \
+            -e 'display dialog (item 1 of argv) with title "SpineCodex Desktop Launcher" buttons {"OK"} default button "OK" with icon stop' \
+            -e 'end run' \
+            "$message" >/dev/null 2>&1
+        then
+            printf '%s\n' "$message" >&2
+        fi
+    else
+        printf '%s\n' "$message" >&2
+    fi
+
+    exit "$exit_code"
+}
+
+handle_error() {
+    local exit_code=$?
+    local failed_command="${BASH_COMMAND:-unknown command}"
+    show_error $'SpineCodex Desktop launch failed.\n\n'"$failed_command" "$exit_code"
+}
+
+codex_desktop_is_running() {
+    [[ "$(osascript -e 'application id "com.openai.codex" is running' 2>/dev/null || true)" == "true" ]]
+}
+
+trap handle_error ERR
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    show_error "This script must be run on macOS."
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+    show_error "npm was not found in PATH."
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+    show_error "Node.js was not found in PATH."
+fi
+
+npm_root="$(npm root -g 2>/dev/null || true)"
+if [[ -z "$npm_root" ]]; then
+    show_error "Could not determine the global npm modules directory."
+fi
+
+node_arch="$(node -p 'process.arch' 2>/dev/null || true)"
+case "$node_arch" in
+    arm64)
+        codex_path="$npm_root/@spinejit/spine-codex/node_modules/@spinejit/spine-codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex"
+        ;;
+    x64)
+        codex_path="$npm_root/@spinejit/spine-codex/node_modules/@spinejit/spine-codex-darwin-x64/vendor/x86_64-apple-darwin/bin/codex"
+        ;;
+    *)
+        show_error "Unsupported Node.js architecture: $node_arch"
+        ;;
+esac
+
+if [[ ! -x "$codex_path" ]]; then
+    show_error $'Could not find the native @spinejit/spine-codex binary:\n\n'"$codex_path"
+fi
+
+if codex_desktop_is_running; then
+    show_error 'Codex Desktop is already running. Quit it before retrying.' 2
+fi
+
+if ! open --env "CODEX_CLI_PATH=$codex_path" --env "CODEX_SPINE_APP_UI=1" -b "com.openai.codex"; then
+    show_error "Could not start Codex Desktop."
+fi
+
+echo "Codex Desktop started with native npm SpineCodex: $codex_path"

--- a/scripts/codex-desktop/start-spinecodex-desktop.ps1
+++ b/scripts/codex-desktop/start-spinecodex-desktop.ps1
@@ -1,0 +1,190 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$dpiSource = @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class SpineCodexDpi
+{
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetThreadDpiAwarenessContext(IntPtr value);
+}
+'@
+
+try {
+    Add-Type -TypeDefinition $dpiSource -ErrorAction Stop
+    [void][SpineCodexDpi]::SetThreadDpiAwarenessContext([IntPtr](-4))
+    Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
+} catch {
+    try {
+        Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
+        [System.Windows.Forms.MessageBox]::Show(
+            $_.Exception.Message,
+            'SpineCodex Desktop Launcher',
+            [System.Windows.Forms.MessageBoxButtons]::OK,
+            [System.Windows.Forms.MessageBoxIcon]::Error
+        ) | Out-Null
+    } catch {
+        [Console]::Error.WriteLine($_.Exception.Message)
+    }
+    exit 1
+}
+
+function Show-LaunchError {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [int]$ExitCode = 1
+    )
+
+    try {
+        [System.Windows.Forms.MessageBox]::Show(
+            $Message,
+            'SpineCodex Desktop Launcher',
+            [System.Windows.Forms.MessageBoxButtons]::OK,
+            [System.Windows.Forms.MessageBoxIcon]::Error
+        ) | Out-Null
+    } catch {
+        [Console]::Error.WriteLine($Message)
+    }
+
+    exit $ExitCode
+}
+
+function ConvertTo-SingleQuotedPowerShellLiteral {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+try {
+    $npmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $npmCommand) {
+        $npmCommand = Get-Command npm -ErrorAction SilentlyContinue
+    }
+    if ($null -eq $npmCommand) {
+        throw 'npm was not found in PATH.'
+    }
+
+    $nodeCommand = Get-Command node.exe -ErrorAction SilentlyContinue
+    if ($null -eq $nodeCommand) {
+        $nodeCommand = Get-Command node -ErrorAction SilentlyContinue
+    }
+    if ($null -ne $nodeCommand) {
+        $nodeExecutable = $nodeCommand.Source
+    } else {
+        $nodeExecutable = Join-Path (Split-Path -Parent $npmCommand.Source) 'node.exe'
+        if (-not (Test-Path -LiteralPath $nodeExecutable -PathType Leaf)) {
+            throw 'Node.js was not found in PATH or next to npm.'
+        }
+    }
+
+    $nodeArchitectureOutput = @(& $nodeExecutable -p 'process.arch')
+    $nodeArchitectureExitCode = $LASTEXITCODE
+    $nodeArchitecture = [string]($nodeArchitectureOutput | Select-Object -First 1)
+    $nodeArchitecture = $nodeArchitecture.Trim()
+    if ($nodeArchitectureExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($nodeArchitecture)) {
+        throw 'Could not determine the Node.js architecture.'
+    }
+    switch ($nodeArchitecture) {
+        'x64' {
+            $nativePackage = '@spinejit\spine-codex-win32-x64'
+            $targetTriple = 'x86_64-pc-windows-msvc'
+        }
+        'arm64' {
+            $nativePackage = '@spinejit\spine-codex-win32-arm64'
+            $targetTriple = 'aarch64-pc-windows-msvc'
+        }
+        default {
+            throw "Unsupported Node.js architecture: $nodeArchitecture"
+        }
+    }
+
+    $npmRootOutput = @(& $npmCommand.Source root -g)
+    $npmRootExitCode = $LASTEXITCODE
+    $npmRoot = [string]($npmRootOutput | Select-Object -First 1)
+    $npmRoot = $npmRoot.Trim()
+    if ($npmRootExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($npmRoot)) {
+        throw 'Could not determine the global npm modules directory.'
+    }
+
+    $native = Join-Path $npmRoot (
+        '@spinejit\spine-codex\node_modules\' +
+        $nativePackage +
+        '\vendor\' +
+        $targetTriple +
+        '\bin\codex.exe'
+    )
+    if (-not (Test-Path -LiteralPath $native -PathType Leaf)) {
+        throw "Could not find the native SpineCodex backend: $native"
+    }
+
+    $packages = @(Get-AppxPackage -Name 'OpenAI.Codex' -ErrorAction SilentlyContinue)
+    $package = $packages |
+        Sort-Object Version -Descending |
+        Select-Object -First 1
+    if ($null -eq $package) {
+        throw 'The official Codex Windows app is not installed.'
+    }
+
+    $manifestPath = Join-Path $package.InstallLocation 'AppxManifest.xml'
+    $manifest = [xml](Get-Content -Raw -LiteralPath $manifestPath)
+    $application = @(
+        $manifest.Package.Applications.Application |
+            Where-Object { $_.Executable }
+    ) | Select-Object -First 1
+    if ($null -eq $application) {
+        throw 'No executable application was found in the Codex package manifest.'
+    }
+
+    $appId = $application.GetAttribute('Id')
+    $relativeExecutable = $application.GetAttribute('Executable')
+    $appExecutable = Join-Path $package.InstallLocation (
+        $relativeExecutable -replace '/', '\'
+    )
+    $packageRoot = [string]$package.InstallLocation
+
+    $allProcesses = @(Get-CimInstance Win32_Process)
+    $running = @(
+        $allProcesses | Where-Object {
+            $_.ExecutablePath -and
+            $_.ExecutablePath.StartsWith(
+                $packageRoot,
+                [System.StringComparison]::OrdinalIgnoreCase
+            ) -and
+            (Split-Path -Leaf $_.ExecutablePath) -in @('ChatGPT.exe', 'Codex.exe')
+        }
+    )
+    if ($running.Count -gt 0) {
+        Show-LaunchError -ExitCode 2 -Message 'Codex Desktop is already running. Quit it before retrying.'
+    }
+
+    $nativeLiteral = ConvertTo-SingleQuotedPowerShellLiteral $native
+    $appLiteral = ConvertTo-SingleQuotedPowerShellLiteral $appExecutable
+    $launchCommand = (
+        '$ErrorActionPreference = ''Stop''; ' +
+        '$env:CODEX_CLI_PATH = ' + $nativeLiteral + '; ' +
+        '$env:CODEX_SPINE_APP_UI = ''1''; ' +
+        'Start-Process -FilePath ' + $appLiteral
+    )
+    $launchArguments = '-NoProfile -NonInteractive -WindowStyle Hidden -Command "' + $launchCommand + '"'
+
+    $launchParameters = @{
+        PackageFamilyName = $package.PackageFamilyName
+        AppId = $appId
+        Command = 'powershell.exe'
+        Args = $launchArguments
+    }
+    Invoke-CommandInDesktopPackage @launchParameters | Out-Null
+
+    Write-Host "Codex Desktop started with native npm SpineCodex: $native"
+} catch {
+    Show-LaunchError -Message $_.Exception.Message
+}


### PR DESCRIPTION
## Summary

- Add Windows and macOS launchers for using the npm-installed SpineCodex backend with Codex Desktop.
- Enable the Spine tree UI when launching Codex Desktop.
- Add launcher instructions to the English and Chinese READMEs.

## Testing

- Verified PowerShell and Bash syntax.
- Verified npm backend discovery on Windows x64 and macOS arm64.
