### PR TITLE
fix(spine): preserve decimal rate limits in paginated Spawn history

### DIFF
--- a/codex-rs/core/tests/suite/spine_spawn.rs
+++ b/codex-rs/core/tests/suite/spine_spawn.rs
@@ -12,6 +12,7 @@ use codex_protocol::protocol::MultiAgentVersion;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::ThreadHistoryMode;
 use codex_protocol::request_user_input::RequestUserInputAnswer;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_protocol::user_input::UserInput;
@@ -437,10 +438,10 @@ async fn build_reverse_completion_fixture(
     ResponseMock,
 )> {
     let server = start_mock_server().await;
-    let _seed_response = mount_sse_once_match(
+    let _seed_response = mount_response_once_match(
         &server,
         |request: &wiremock::Request| body_contains(request, SEED_PARENT_PROMPT),
-        sse(vec![
+        sse_response(sse(vec![
             ev_response_created("seed-response"),
             ev_reasoning_item("seed-reasoning-without-content", &["omitted"], &[]),
             ev_reasoning_item(
@@ -450,7 +451,10 @@ async fn build_reverse_completion_fixture(
             ),
             ev_assistant_message("seed-message", "seed complete"),
             ev_completed("seed-response"),
-        ]),
+        ]))
+        .insert_header("x-codex-primary-used-percent", "12.5")
+        .insert_header("x-codex-primary-window-minutes", "10080")
+        .insert_header("x-codex-primary-reset-at", "1789200718"),
     )
     .await;
     let parent_spawn = mount_sse_once_match(
@@ -505,7 +509,10 @@ async fn build_reverse_completion_fixture(
         ]),
     )
     .await;
-    let test = metadata_v2_spine_builder().build(&server).await?;
+    let test = metadata_v2_spine_builder()
+        .with_history_mode(ThreadHistoryMode::Paginated)
+        .build_with_auto_env(&server)
+        .await?;
     assert!(test.config.features.enabled(Feature::SpineSpawn));
     assert!(!test.config.features.enabled(Feature::MultiAgentV2));
     let selected_model = test

--- a/codex-rs/thread-store/src/local/paginated_fork.rs
+++ b/codex-rs/thread-store/src/local/paginated_fork.rs
@@ -286,14 +286,16 @@ fn find_spine_sampling_boundary_blocking(
             if line.trim().is_empty() {
                 continue;
             }
-            let record: RolloutLine = serde_json::from_str(line.trim_end()).map_err(|err| {
-                ThreadStoreError::InvalidRequest {
+            // Decode through JSON Value, as the rollout recorder does, so flattened
+            // records preserve decimal values with serde_json/arbitrary_precision.
+            let record: RolloutLine = serde_json::from_str::<serde_json::Value>(line.trim_end())
+                .and_then(serde_json::from_value)
+                .map_err(|err| ThreadStoreError::InvalidRequest {
                     message: format!(
                         "invalid sampling-boundary record in {}: {err}",
                         segment.rollout_path.display()
                     ),
-                }
-            })?;
+                })?;
             let ordinal = record
                 .ordinal
                 .ok_or_else(|| ThreadStoreError::InvalidRequest {

--- a/codex-rs/thread-store/src/local/paginated_fork_tests.rs
+++ b/codex-rs/thread-store/src/local/paginated_fork_tests.rs
@@ -20,6 +20,66 @@ use crate::local::rollout_lineage::RolloutLineage;
 use crate::local::rollout_lineage::RolloutLineageSegment;
 
 #[tokio::test]
+async fn sampling_boundary_preserves_decimal_rate_limits() {
+    let home = TempDir::new().expect("temp dir");
+    let thread_id = ThreadId::new();
+    let rate_limits: RolloutItem = serde_json::from_value(json!({
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": null,
+            "rate_limits": {
+                "primary": {
+                    "used_percent": 28.0,
+                    "window_minutes": 10080,
+                    "resets_at": 1789200718
+                }
+            }
+        }
+    }))
+    .expect("rate limit event");
+    let started = sampling_started("open");
+    let path = write_rollout(
+        home.path(),
+        thread_id,
+        /*history_base*/ None,
+        /*session_meta_ordinal*/ 0,
+        vec![rate_limits.clone(), started.clone()],
+    );
+    let expected_position = HistoryPosition {
+        thread_id,
+        end_ordinal_exclusive: 3,
+        end_byte_offset: fs::metadata(&path).expect("rollout metadata").len(),
+    };
+    let session_meta = codex_rollout::read_session_meta_line(&path)
+        .await
+        .expect("session metadata");
+    let lineage = RolloutLineage {
+        segments: vec![RolloutLineageSegment {
+            thread_id,
+            rollout_path: path,
+            start_ordinal: 1,
+            end: None,
+        }],
+    };
+
+    let selected = find_spine_sampling_boundary(&lineage)
+        .await
+        .expect("select sampling boundary after rate limit event");
+
+    assert_eq!(selected.position, expected_position);
+    assert_eq!(
+        serde_json::to_value(selected.complete_history.as_ref()).expect("selected history"),
+        serde_json::to_value(vec![
+            RolloutItem::SessionMeta(session_meta),
+            rate_limits,
+            started
+        ])
+        .expect("expected history")
+    );
+}
+
+#[tokio::test]
 async fn selects_latest_uncommitted_sampling_boundary_across_lineage() {
     let home = TempDir::new().expect("temp dir");
     let root_id = ThreadId::new();


### PR DESCRIPTION
## Problem and fix

With paginated parent history, a persisted decimal rate-limit value such as `used_percent: 28.0` makes Spine's sampling-boundary scan fail with `invalid type: map, expected f64`. Child branches fail before their first model request.

Decode the line through `serde_json::Value` before deserializing `RolloutLine`, matching the existing rollout recorder on this baseline. This preserves the complete history and numeric values. The change touches three files and targets the current `main` / Codex 0.147.0 baseline.

This is the standalone backport requested in #11. The Codex 0.153.4 migration is tracked separately in #12.

## Validation

Validated at `e01826e128a8750824c2c6b0109d9a4ec98a45dc` on macOS ARM64:

- Red/green regression: the new sampling-boundary test fails on the original decoder with the reported error; all 186 `codex-thread-store` tests pass after the fix (0 skipped).
- Full `codex-core` run: 3,451 passed, 11 failed, 1 timed out, 19 skipped.
- Same-environment baseline comparison: reran all 12 failures/timeouts serially on unmodified `upstream/main` (`98ee6314e`). Both image-related tests passed; the other 10 failures reproduced.
- Reran those 12 tests plus all 19 Spawn integration tests serially on the PR head: 21 passed; the same 10 baseline failures remained. The Spawn tests cover paginated concurrent children with reverse completion, decimal rate-limit headers, routing, failures, interruption and capacity reuse.
- The 10 baseline failures are five WebSocket product/compatibility User-Agent assertions, one debug-prompt user-label assertion, and four token-budget assertions. These are outside this decoder fix.
- CLI, code-mode host and MCP test binaries built successfully. Local tests used bundled/static liblzma to support macOS sandbox execution.
- `just fmt` completed successfully; formatter-only changes in three unrelated baseline files were restored. `git diff --check` passed and the worktree is clean.

The full core suite retains the documented baseline failures; the focused fix and all Spawn integration coverage pass.
